### PR TITLE
Remove the dependency on Polymer.Element

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,33 +8,54 @@
       "sourceRange": {
         "file": "vaadin-router.html",
         "start": {
-          "line": 51,
-          "column": 6
+          "line": 39,
+          "column": 4
         },
         "end": {
-          "line": 51,
-          "column": 42
+          "line": 39,
+          "column": 40
         }
       },
       "elements": [
         {
-          "description": "`<vaadin-route>` is a Polymer 2 element.\n\n```\n<vaadin-route></vaadin-route>\n```",
+          "description": "`<vaadin-route>` is a Web Component that defines a single route for the\n`<vaadin-router>` component.\n\n```\n<vaadin-route path=\"/users/:user\">\n  <x-user-view></x-user-view>\n</vaadin-route>\n```",
           "summary": "",
           "path": "vaadin-route.html",
           "properties": [
             {
-              "name": "url",
+              "name": "router",
+              "type": "{pathname: string}",
+              "description": "Exposes the current path of the Vaadin Router",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-router-mixin.html",
+                "start": {
+                  "line": 38,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.RouterMixin"
+            },
+            {
+              "name": "path",
               "type": "string",
-              "description": "",
+              "description": "Defines the path served by this route",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 42,
-                  "column": 12
+                  "line": 40,
+                  "column": 10
                 },
                 "end": {
-                  "line": 44,
-                  "column": 13
+                  "line": 40,
+                  "column": 22
                 }
               },
               "metadata": {
@@ -42,260 +63,129 @@
               }
             },
             {
-              "name": "active",
-              "type": "boolean",
+              "name": "_parameters",
+              "type": "Array",
               "description": "",
-              "privacy": "public",
+              "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 45,
-                  "column": 12
+                  "line": 42,
+                  "column": 10
                 },
                 "end": {
-                  "line": 49,
-                  "column": 13
+                  "line": 42,
+                  "column": 28
                 }
               },
               "metadata": {
-                "polymer": {
-                  "observer": "\"_onActiveChanged\""
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_regexp",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 43,
+                  "column": 10
+                },
+                "end": {
+                  "line": 43,
+                  "column": 25
                 }
               },
-              "defaultValue": "false"
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_routeTemplate",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 44,
+                  "column": 10
+                },
+                "end": {
+                  "line": 44,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_templateInstance",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 45,
+                  "column": 10
+                },
+                "end": {
+                  "line": 45,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
             }
           ],
           "methods": [
             {
-              "name": "_activeRouteChanged",
+              "name": "connectedCallback",
               "description": "",
-              "privacy": "protected",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 49,
+                  "column": 6
+                },
+                "end": {
+                  "line": 57,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "public",
               "sourceRange": {
                 "start": {
                   "line": 59,
-                  "column": 8
+                  "column": 6
                 },
                 "end": {
-                  "line": 61,
-                  "column": 9
+                  "line": 62,
+                  "column": 7
                 }
               },
               "metadata": {},
               "params": []
             },
             {
-              "name": "_onActiveChanged",
+              "name": "_onPopstate",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 63,
-                  "column": 8
+                  "line": 92,
+                  "column": 6
                 },
                 "end": {
-                  "line": 82,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "newValue"
-                },
-                {
-                  "name": "oldValue"
-                }
-              ]
-            },
-            {
-              "name": "_render",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 84,
-                  "column": 8
-                },
-                "end": {
-                  "line": 99,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template"
-                }
-              ]
-            },
-            {
-              "name": "_clear",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 101,
-                  "column": 8
-                },
-                "end": {
-                  "line": 106,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            }
-          ],
-          "staticMethods": [],
-          "demos": [],
-          "metadata": {},
-          "sourceRange": {
-            "start": {
-              "line": 35,
-              "column": 6
-            },
-            "end": {
-              "line": 107,
-              "column": 7
-            }
-          },
-          "privacy": "public",
-          "superclass": "HTMLElement",
-          "name": "Vaadin.VaadinRoute",
-          "attributes": [
-            {
-              "name": "url",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 42,
-                  "column": 12
-                },
-                "end": {
-                  "line": 44,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "string"
-            },
-            {
-              "name": "active",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 45,
-                  "column": 12
-                },
-                "end": {
-                  "line": 49,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            }
-          ],
-          "events": [],
-          "styling": {
-            "cssVariables": [],
-            "selectors": []
-          },
-          "slots": [
-            {
-              "description": "",
-              "name": "",
-              "range": {
-                "file": "vaadin-route.html",
-                "start": {
-                  "line": 20,
-                  "column": 4
-                },
-                "end": {
-                  "line": 20,
-                  "column": 17
-                }
-              }
-            }
-          ],
-          "tagname": "vaadin-route"
-        },
-        {
-          "description": "`<vaadin-router-link>` is a Polymer 2 element.\n\n```\n<vaadin-router-link></vaadin-router-link>\n```",
-          "summary": "",
-          "path": "vaadin-router-link.html",
-          "properties": [
-            {
-              "name": "href",
-              "type": "string",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 50,
-                  "column": 12
-                },
-                "end": {
-                  "line": 52,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "active",
-              "type": "boolean",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 53,
-                  "column": 12
-                },
-                "end": {
-                  "line": 58,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "notify": true
-                }
-              },
-              "defaultValue": "false"
-            }
-          ],
-          "methods": [
-            {
-              "name": "_activeRouteChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 68,
-                  "column": 8
-                },
-                "end": {
-                  "line": 70,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_onClick",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 72,
-                  "column": 8
-                },
-                "end": {
-                  "line": 76,
-                  "column": 9
+                  "line": 95,
+                  "column": 7
                 }
               },
               "metadata": {},
@@ -304,819 +194,6 @@
                   "name": "event"
                 }
               ]
-            }
-          ],
-          "staticMethods": [],
-          "demos": [],
-          "metadata": {},
-          "sourceRange": {
-            "start": {
-              "line": 43,
-              "column": 6
-            },
-            "end": {
-              "line": 77,
-              "column": 7
-            }
-          },
-          "privacy": "public",
-          "superclass": "HTMLElement",
-          "name": "Vaadin.VaadinRouterLink",
-          "attributes": [
-            {
-              "name": "href",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 50,
-                  "column": 12
-                },
-                "end": {
-                  "line": 52,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "string"
-            },
-            {
-              "name": "active",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 53,
-                  "column": 12
-                },
-                "end": {
-                  "line": 58,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            }
-          ],
-          "events": [
-            {
-              "type": "CustomEvent",
-              "name": "active-changed",
-              "description": "Fired when the `active` property changes.",
-              "metadata": {}
-            }
-          ],
-          "styling": {
-            "cssVariables": [],
-            "selectors": []
-          },
-          "slots": [
-            {
-              "description": "",
-              "name": "",
-              "range": {
-                "file": "vaadin-router-link.html",
-                "start": {
-                  "line": 28,
-                  "column": 6
-                },
-                "end": {
-                  "line": 28,
-                  "column": 19
-                }
-              }
-            }
-          ],
-          "tagname": "vaadin-router-link"
-        },
-        {
-          "description": "`<vaadin-router>` is a Polymer 2 element.\n\n```\n<vaadin-router></vaadin-router>\n```",
-          "summary": "",
-          "path": "vaadin-router.html",
-          "properties": [
-            {
-              "name": "__dataClientsReady",
-              "type": "boolean",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1139,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1139,
-                  "column": 32
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataPendingClients",
-              "type": "Array",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1141,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1141,
-                  "column": 34
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataToNotify",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1143,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1143,
-                  "column": 28
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataLinkedPaths",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1145,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1145,
-                  "column": 31
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataHasPaths",
-              "type": "boolean",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1147,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1147,
-                  "column": 28
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataCompoundStorage",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1149,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1149,
-                  "column": 35
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataHost",
-              "type": "Polymer_PropertyEffects",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1151,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1151,
-                  "column": 24
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataTemp",
-              "type": "!Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1153,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1153,
-                  "column": 24
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataClientsInitialized",
-              "type": "boolean",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1155,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1155,
-                  "column": 38
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__data",
-              "type": "!Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1157,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1157,
-                  "column": 20
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataPending",
-              "type": "!Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1159,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1159,
-                  "column": 27
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__dataOld",
-              "type": "!Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1161,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1161,
-                  "column": 23
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__computeEffects",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1163,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1163,
-                  "column": 30
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__reflectEffects",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1165,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1165,
-                  "column": 30
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__notifyEffects",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1167,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1167,
-                  "column": 29
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__propagateEffects",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1169,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1169,
-                  "column": 32
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__observeEffects",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1171,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1171,
-                  "column": 30
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__readOnly",
-              "type": "Object",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1173,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1173,
-                  "column": 24
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__templateInfo",
-              "type": "!TemplateInfo",
-              "description": "",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1175,
-                  "column": 8
-                },
-                "end": {
-                  "line": 1175,
-                  "column": 28
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_template",
-              "type": "HTMLTemplateElement",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 421,
-                  "column": 8
-                },
-                "end": {
-                  "line": 421,
-                  "column": 23
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "_importPath",
-              "type": "string",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 423,
-                  "column": 8
-                },
-                "end": {
-                  "line": 423,
-                  "column": 25
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "rootPath",
-              "type": "string",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 425,
-                  "column": 8
-                },
-                "end": {
-                  "line": 425,
-                  "column": 22
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "importPath",
-              "type": "string",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 427,
-                  "column": 8
-                },
-                "end": {
-                  "line": 427,
-                  "column": 24
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "root",
-              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 429,
-                  "column": 8
-                },
-                "end": {
-                  "line": 429,
-                  "column": 18
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "$",
-              "type": "!Object.<string, !Element>",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 431,
-                  "column": 8
-                },
-                "end": {
-                  "line": 431,
-                  "column": 15
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": false
-                }
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            }
-          ],
-          "methods": [
-            {
-              "name": "_stampTemplate",
-              "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2415,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2440,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template",
-                  "type": "!HTMLTemplateElement",
-                  "description": "Template to stamp"
-                }
-              ],
-              "return": {
-                "type": "!StampedTemplate",
-                "desc": "Cloned template content"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_addMethodEventListenerToNode",
-              "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 452,
-                  "column": 6
-                },
-                "end": {
-                  "line": 457,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "!Node",
-                  "description": "Node to add listener on"
-                },
-                {
-                  "name": "eventName",
-                  "type": "string",
-                  "description": "Name of event"
-                },
-                {
-                  "name": "methodName",
-                  "type": "string",
-                  "description": "Name of method"
-                },
-                {
-                  "name": "context",
-                  "type": "*=",
-                  "description": "Context the method will be called on (defaults\n  to `node`)"
-                }
-              ],
-              "return": {
-                "type": "Function",
-                "desc": "Generated handler function"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
-              "name": "_addEventListenerToNode",
-              "description": "Override point for adding custom or simulated event handling.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 467,
-                  "column": 6
-                },
-                "end": {
-                  "line": 469,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "!Node",
-                  "description": "Node to add event listener to"
-                },
-                {
-                  "name": "eventName",
-                  "type": "string",
-                  "description": "Name of event"
-                },
-                {
-                  "name": "handler",
-                  "type": "function (!Event): void",
-                  "description": "Listener function to add"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
-              "name": "_removeEventListenerFromNode",
-              "description": "Override point for adding custom or simulated event handling.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 479,
-                  "column": 6
-                },
-                "end": {
-                  "line": 481,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "Node",
-                  "description": "Node to remove event listener from"
-                },
-                {
-                  "name": "eventName",
-                  "type": "string",
-                  "description": "Name of event"
-                },
-                {
-                  "name": "handler",
-                  "type": "function (!Event): void",
-                  "description": "Listener function to remove"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
             },
             {
               "name": "_createPropertyAccessor",
@@ -1211,17 +288,17 @@
             },
             {
               "name": "ready",
-              "description": "Stamps the element template.",
-              "privacy": "protected",
+              "description": "Lifecycle callback called when properties are enabled via\n`_enableProperties`.\n\nUsers may override this function to implement behavior that is\ndependent on the element having its property data initialized, e.g.\nfrom defaults (initialized from `constructor`, `_initializeProperties`),\n`attributeChangedCallback`, or values propagated from host e.g. via\nbindings.  `super.ready()` must be called to ensure the data system\nbecomes enabled.",
+              "privacy": "public",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 540,
-                  "column": 6
+                  "line": 182,
+                  "column": 8
                 },
                 "end": {
-                  "line": 546,
-                  "column": 7
+                  "line": 185,
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1229,20 +306,20 @@
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.ElementMixin"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
               "name": "_initializeProperties",
-              "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+              "description": "Overrides `PropertiesChanged` method and adds a call to\n`finalize` which lazily configures the element's property accessors.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 446,
+                  "line": 191,
                   "column": 6
                 },
                 "end": {
-                  "line": 480,
+                  "line": 194,
                   "column": 7
                 }
               },
@@ -1251,7 +328,7 @@
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.ElementMixin"
+              "inheritedFrom": "Polymer.PropertiesMixin"
             },
             {
               "name": "_initializeInstanceProperties",
@@ -1437,7 +514,7 @@
                   "column": 8
                 },
                 "end": {
-                  "line": 339,
+                  "line": 342,
                   "column": 9
                 }
               },
@@ -1449,17 +526,17 @@
               "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "_propertiesChanged",
-              "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "name": "_shouldPropertiesChange",
+              "description": "Called in `_flushProperties` to determine if `_propertiesChanged`\nshould be called. The default implementation returns true if\nproperties are pending. Override to customize when\n`_propertiesChanged` is called.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 353,
+                  "line": 356,
                   "column": 8
                 },
                 "end": {
-                  "line": 354,
+                  "line": 358,
                   "column": 9
                 }
               },
@@ -1482,9 +559,46 @@
                 }
               ],
               "return": {
-                "type": "void"
+                "type": "boolean",
+                "desc": "true if changedProps is truthy"
               },
               "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "(override of `Polymer.PropertiesChanged._propertiesChanged)\n\nCallback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 78,
+                  "column": 6
+                },
+                "end": {
+                  "line": 90,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              }
             },
             {
               "name": "_shouldPropertyChange",
@@ -1493,11 +607,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 374,
+                  "line": 393,
                   "column": 8
                 },
                 "end": {
-                  "line": 381,
+                  "line": 400,
                   "column": 9
                 }
               },
@@ -1532,11 +646,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 393,
+                  "line": 412,
                   "column": 8
                 },
                 "end": {
-                  "line": 400,
+                  "line": 419,
                   "column": 9
                 }
               },
@@ -1570,11 +684,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 414,
+                  "line": 433,
                   "column": 8
                 },
                 "end": {
-                  "line": 421,
+                  "line": 440,
                   "column": 9
                 }
               },
@@ -1608,11 +722,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 433,
+                  "line": 452,
                   "column": 8
                 },
                 "end": {
-                  "line": 439,
+                  "line": 458,
                   "column": 9
                 }
               },
@@ -1646,11 +760,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 454,
+                  "line": 473,
                   "column": 8
                 },
                 "end": {
-                  "line": 461,
+                  "line": 480,
                   "column": 9
                 }
               },
@@ -1684,11 +798,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 474,
+                  "line": 493,
                   "column": 8
                 },
                 "end": {
-                  "line": 481,
+                  "line": 500,
                   "column": 9
                 }
               },
@@ -1713,11 +827,11 @@
               "sourceRange": {
                 "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 495,
+                  "line": 514,
                   "column": 8
                 },
                 "end": {
-                  "line": 504,
+                  "line": 523,
                   "column": 9
                 }
               },
@@ -1741,1684 +855,137 @@
               "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "_initializeProtoProperties",
-              "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+              "name": "_onPathChanged",
+              "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1209,
+                  "line": 97,
                   "column": 6
                 },
                 "end": {
-                  "line": 1213,
+                  "line": 101,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "props",
-                  "type": "Object",
-                  "description": "Properties to initialize on the prototype"
+                  "name": "newValue"
+                },
+                {
+                  "name": "oldValue"
                 }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              ]
             },
             {
-              "name": "_ensureAttribute",
-              "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+              "name": "_onRouteTemplateChanged",
+              "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 192,
+                  "line": 103,
                   "column": 6
                 },
                 "end": {
-                  "line": 197,
+                  "line": 110,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "attribute",
-                  "type": "string",
-                  "description": "Name of attribute to ensure is set."
+                  "name": "newValue"
                 },
                 {
-                  "name": "value",
-                  "type": "string",
-                  "description": "of the attribute."
+                  "name": "oldValue"
                 }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyAccessors"
+              ]
             },
             {
-              "name": "_hasAccessor",
-              "description": "Returns true if this library created an accessor for the given property.",
+              "name": "_onRenderCriteriaChanged",
+              "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 299,
+                  "line": 112,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 122,
                   "column": 7
                 }
               },
               "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if an accessor was created"
-              },
-              "inheritedFrom": "Polymer.PropertyAccessors"
+              "params": []
             },
             {
-              "name": "_isPropertyPending",
-              "description": "Returns true if the specified property has a pending change.",
+              "name": "_render",
+              "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 310,
+                  "line": 124,
                   "column": 6
                 },
                 "end": {
-                  "line": 312,
+                  "line": 134,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "prop",
-                  "type": "string",
-                  "description": "Property name"
+                  "name": "match"
                 }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if property has a pending change"
-              },
-              "inheritedFrom": "Polymer.PropertyAccessors"
+              ]
             },
             {
-              "name": "_addPropertyEffect",
-              "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "name": "_clear",
+              "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1247,
+                  "line": 136,
                   "column": 6
                 },
                 "end": {
-                  "line": 1255,
+                  "line": 141,
                   "column": 7
                 }
               },
               "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property that should trigger the effect"
-                },
-                {
-                  "name": "type",
-                  "type": "string",
-                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-                },
-                {
-                  "name": "effect",
-                  "type": "Object=",
-                  "description": "Effect metadata object"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_removePropertyEffect",
-              "description": "Removes the given property effect.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1265,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1271,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property the effect was associated with"
-                },
-                {
-                  "name": "type",
-                  "type": "string",
-                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-                },
-                {
-                  "name": "effect",
-                  "type": "Object=",
-                  "description": "Effect metadata object to remove"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_hasPropertyEffect",
-              "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1282,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1285,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                },
-                {
-                  "name": "type",
-                  "type": "string=",
-                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the prototype/instance has an effect of this type"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_hasReadOnlyEffect",
-              "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1295,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1297,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the prototype/instance has an effect of this type"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_hasNotifyEffect",
-              "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1307,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1309,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the prototype/instance has an effect of this type"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_hasReflectEffect",
-              "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1319,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1321,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the prototype/instance has an effect of this type"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_hasComputedEffect",
-              "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1331,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1333,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "True if the prototype/instance has an effect of this type"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_setPendingPropertyOrPath",
-              "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1365,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1397,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(number | string)>)",
-                  "description": "Path to set"
-                },
-                {
-                  "name": "value",
-                  "type": "*",
-                  "description": "Value to set"
-                },
-                {
-                  "name": "shouldNotify",
-                  "type": "boolean=",
-                  "description": "Set to true if this change should\n cause a property notification event dispatch"
-                },
-                {
-                  "name": "isPathNotification",
-                  "type": "boolean=",
-                  "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_setUnmanagedPropertyToNode",
-              "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1420,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1428,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "!Node",
-                  "description": "The node to set a property on"
-                },
-                {
-                  "name": "prop",
-                  "type": "string",
-                  "description": "The property to set"
-                },
-                {
-                  "name": "value",
-                  "type": "*",
-                  "description": "The value to set"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_enqueueClient",
-              "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1535,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1540,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "client",
-                  "type": "Object",
-                  "description": "PropertyEffects client to enqueue"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_flushClients",
-              "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1561,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1572,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "__enableOrFlushClients",
-              "description": "(c) the stamped dom enables.",
-              "privacy": "private",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1586,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1599,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_readyClients",
-              "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 558,
-                  "column": 6
-                },
-                "end": {
-                  "line": 567,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "setProperties",
-              "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1628,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1639,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "props",
-                  "type": "Object",
-                  "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
-                },
-                {
-                  "name": "setReadOnly",
-                  "type": "boolean=",
-                  "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_propagatePropertyChanges",
-              "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1726,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1736,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "changedProps",
-                  "type": "Object",
-                  "description": "Bag of changed properties"
-                },
-                {
-                  "name": "oldProps",
-                  "type": "Object",
-                  "description": "Bag of previous values for changed properties"
-                },
-                {
-                  "name": "hasPaths",
-                  "type": "boolean",
-                  "description": "True with `props` contains one or more paths"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "linkPaths",
-              "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1747,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1752,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "to",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Target path to link."
-                },
-                {
-                  "name": "from",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Source path to link."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "unlinkPaths",
-              "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1764,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1769,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Target path to unlink."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "notifySplices",
-              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1801,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1805,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "string",
-                  "description": "Path that should be notified."
-                },
-                {
-                  "name": "splices",
-                  "type": "Array",
-                  "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "get",
-              "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1826,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1828,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
-                },
-                {
-                  "name": "root",
-                  "type": "Object=",
-                  "description": "Root object from which the path is evaluated."
-                }
-              ],
-              "return": {
-                "type": "*",
-                "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "set",
-              "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1851,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1861,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
-                },
-                {
-                  "name": "value",
-                  "type": "*",
-                  "description": "Value to set at the specified path."
-                },
-                {
-                  "name": "root",
-                  "type": "Object=",
-                  "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "push",
-              "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1877,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1886,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to array."
-                },
-                {
-                  "name": "items",
-                  "type": "...*",
-                  "rest": true,
-                  "description": "Items to push onto array"
-                }
-              ],
-              "return": {
-                "type": "number",
-                "desc": "New length of the array."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "pop",
-              "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1901,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1910,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to array."
-                }
-              ],
-              "return": {
-                "type": "*",
-                "desc": "Item that was removed."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "splice",
-              "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1929,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1966,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to array."
-                },
-                {
-                  "name": "start",
-                  "type": "number",
-                  "description": "Index from which to start removing/inserting."
-                },
-                {
-                  "name": "deleteCount",
-                  "type": "number",
-                  "description": "Number of items to remove."
-                },
-                {
-                  "name": "items",
-                  "type": "...*",
-                  "rest": true,
-                  "description": "Items to insert into array."
-                }
-              ],
-              "return": {
-                "type": "Array",
-                "desc": "Array of removed items."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "shift",
-              "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 1981,
-                  "column": 6
-                },
-                "end": {
-                  "line": 1990,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to array."
-                }
-              ],
-              "return": {
-                "type": "*",
-                "desc": "Item that was removed."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "unshift",
-              "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2006,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2014,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "(string | !Array.<(string | number)>)",
-                  "description": "Path to array."
-                },
-                {
-                  "name": "items",
-                  "type": "...*",
-                  "rest": true,
-                  "description": "Items to insert info array"
-                }
-              ],
-              "return": {
-                "type": "number",
-                "desc": "New length of the array."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "notifyPath",
-              "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2029,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2046,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "path",
-                  "type": "string",
-                  "description": "Path that should be notified."
-                },
-                {
-                  "name": "value",
-                  "type": "*=",
-                  "description": "Value at the path (optional)."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createReadOnlyProperty",
-              "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2059,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2066,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                },
-                {
-                  "name": "protectedSetter",
-                  "type": "boolean=",
-                  "description": "Creates a custom protected setter\n  when `true`."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createPropertyObserver",
-              "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2080,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2090,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                },
-                {
-                  "name": "method",
-                  "type": "(string | function (*, *))",
-                  "description": "Function or name of observer method to call"
-                },
-                {
-                  "name": "dynamicFn",
-                  "type": "boolean=",
-                  "description": "Whether the method name should be included as\n  a dependency to the effect."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createMethodObserver",
-              "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2103,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2109,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "expression",
-                  "type": "string",
-                  "description": "Method expression"
-                },
-                {
-                  "name": "dynamicFn",
-                  "type": "(boolean | Object)=",
-                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createNotifyingProperty",
-              "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2120,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2128,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createReflectedProperty",
-              "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2139,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2152,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_createComputedProperty",
-              "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2166,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2172,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Name of computed property to set"
-                },
-                {
-                  "name": "expression",
-                  "type": "string",
-                  "description": "Method expression"
-                },
-                {
-                  "name": "dynamicFn",
-                  "type": "(boolean | Object)=",
-                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_bindTemplate",
-              "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2349,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2372,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template",
-                  "type": "!HTMLTemplateElement",
-                  "description": "Template containing binding\n  bindings"
-                },
-                {
-                  "name": "instanceBinding",
-                  "type": "boolean=",
-                  "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
-                }
-              ],
-              "return": {
-                "type": "!TemplateInfo",
-                "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_removeBoundDom",
-              "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2451,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2472,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "dom",
-                  "type": "!StampedTemplate",
-                  "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "connectedCallback",
-              "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 527,
-                  "column": 6
-                },
-                "end": {
-                  "line": 532,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "disconnectedCallback",
-              "description": "Called when the element is removed from a document",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
-                "start": {
-                  "line": 215,
-                  "column": 6
-                },
-                "end": {
-                  "line": 219,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertiesMixin"
-            },
-            {
-              "name": "_attachDom",
-              "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 581,
-                  "column": 6
-                },
-                "end": {
-                  "line": 597,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "dom",
-                  "type": "StampedTemplate",
-                  "description": "to attach to the element."
-                }
-              ],
-              "return": {
-                "type": "ShadowRoot",
-                "desc": "node to which the dom has been attached."
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "updateStyles",
-              "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 617,
-                  "column": 6
-                },
-                "end": {
-                  "line": 621,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "properties",
-                  "type": "Object=",
-                  "description": "Bag of custom property key/values to\n  apply to this element."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "resolveUrl",
-              "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.\n\nNote that this function performs no resolution for URLs that start\nwith `/` (absolute URLs) or `#` (hash identifiers).  For general purpose\nURL resolution, use `window.URL`.",
-              "privacy": "public",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 638,
-                  "column": 6
-                },
-                "end": {
-                  "line": 643,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "url",
-                  "type": "string",
-                  "description": "URL to resolve."
-                },
-                {
-                  "name": "base",
-                  "type": "string=",
-                  "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
-                }
-              ],
-              "return": {
-                "type": "string",
-                "desc": "Rewritten URL relative to base"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
+              "params": []
             }
           ],
           "staticMethods": [
             {
-              "name": "_parseTemplate",
-              "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 197,
-                  "column": 6
-                },
-                "end": {
-                  "line": 208,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template",
-                  "type": "!HTMLTemplateElement",
-                  "description": "Template to parse"
-                },
-                {
-                  "name": "outerTemplateInfo",
-                  "type": "TemplateInfo=",
-                  "description": "Template metadata from the outer\n  template, for parsing nested templates"
-                }
-              ],
-              "return": {
-                "type": "!TemplateInfo",
-                "desc": "Parsed template metadata"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
-              "name": "_parseTemplateContent",
-              "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 654,
-                  "column": 6
-                },
-                "end": {
-                  "line": 657,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template"
-                },
-                {
-                  "name": "templateInfo"
-                },
-                {
-                  "name": "nodeInfo"
-                }
-              ],
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "_parseTemplateNode",
-              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2491,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2505,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "Node",
-                  "description": "Node to parse"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "TemplateInfo",
-                  "description": "Template metadata for current template"
-                },
-                {
-                  "name": "nodeInfo",
-                  "type": "NodeInfo",
-                  "description": "Node metadata for current template node"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_parseTemplateChildNodes",
-              "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 258,
-                  "column": 6
-                },
-                "end": {
-                  "line": 295,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "root",
-                  "type": "Node",
-                  "description": "Root node whose `childNodes` will be parsed"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "!TemplateInfo",
-                  "description": "Template metadata for current template"
-                },
-                {
-                  "name": "nodeInfo",
-                  "type": "!NodeInfo",
-                  "description": "Node metadata for current template."
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
-              "name": "_parseTemplateNestedTemplate",
-              "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2578,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2588,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "Node",
-                  "description": "Node to parse"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "TemplateInfo",
-                  "description": "Template metadata for current template"
-                },
-                {
-                  "name": "nodeInfo",
-                  "type": "NodeInfo",
-                  "description": "Node metadata for current template node"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_parseTemplateNodeAttributes",
-              "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 333,
-                  "column": 6
-                },
-                "end": {
-                  "line": 342,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "Element",
-                  "description": "Node to parse"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "TemplateInfo",
-                  "description": "Template metadata for current template"
-                },
-                {
-                  "name": "nodeInfo",
-                  "type": "NodeInfo",
-                  "description": "Node metadata for current template."
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
-              "name": "_parseTemplateNodeAttribute",
-              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2526,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2562,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "node",
-                  "type": "Element",
-                  "description": "Node to parse"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "TemplateInfo",
-                  "description": "Template metadata for current template"
-                },
-                {
-                  "name": "nodeInfo",
-                  "type": "NodeInfo",
-                  "description": "Node metadata for current template node"
-                },
-                {
-                  "name": "name",
-                  "type": "string",
-                  "description": "Attribute name"
-                },
-                {
-                  "name": "value",
-                  "type": "string",
-                  "description": "Attribute value"
-                }
-              ],
-              "return": {
-                "type": "boolean",
-                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_contentForTemplate",
-              "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
-                "start": {
-                  "line": 388,
-                  "column": 6
-                },
-                "end": {
-                  "line": 391,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "template",
-                  "type": "HTMLTemplateElement",
-                  "description": "Template to retrieve `content` for"
-                }
-              ],
-              "return": {
-                "type": "DocumentFragment",
-                "desc": "Content fragment"
-              },
-              "inheritedFrom": "Polymer.TemplateStamp"
-            },
-            {
               "name": "createProperties",
-              "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+              "description": "Creates property accessors for the given property names.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 325,
-                  "column": 7
+                  "line": 58,
+                  "column": 8
                 },
                 "end": {
-                  "line": 329,
-                  "column": 7
+                  "line": 66,
+                  "column": 9
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "props"
+                  "name": "props",
+                  "type": "!Object",
+                  "description": "Object whose keys are names of accessors."
                 }
               ],
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.ElementMixin"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
               "name": "attributeNameForProperty",
@@ -3479,17 +1046,17 @@
               "inheritedFrom": "Polymer.PropertiesMixin"
             },
             {
-              "name": "createPropertiesForAttributes",
-              "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+              "name": "finalize",
+              "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
               "privacy": "public",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
                   "line": 128,
                   "column": 6
                 },
                 "end": {
-                  "line": 133,
+                  "line": 137,
                   "column": 7
                 }
               },
@@ -3498,21 +1065,225 @@
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.PropertyAccessors"
+              "inheritedFrom": "Polymer.PropertiesMixin"
             },
             {
-              "name": "addPropertyEffect",
-              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "name": "_finalizeClass",
+              "description": "Finalize an element class. This includes ensuring property\naccessors exist on the element prototype. This method is called by\n`finalize` and finalizes the class constructor.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 2212,
+                  "line": 146,
                   "column": 6
                 },
                 "end": {
-                  "line": 2214,
+                  "line": 151,
                   "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            }
+          ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 32,
+              "column": 4
+            },
+            "end": {
+              "line": 142,
+              "column": 5
+            }
+          },
+          "privacy": "public",
+          "superclass": "HTMLElement",
+          "name": "Vaadin.RouteElement",
+          "attributes": [
+            {
+              "name": "router",
+              "description": "Exposes the current path of the Vaadin Router",
+              "sourceRange": {
+                "file": "vaadin-router-mixin.html",
+                "start": {
+                  "line": 38,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 22
+                }
+              },
+              "metadata": {},
+              "type": "{pathname: string}",
+              "inheritedFrom": "Vaadin.RouterMixin"
+            },
+            {
+              "name": "path",
+              "description": "Defines the path served by this route",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 10
+                },
+                "end": {
+                  "line": 40,
+                  "column": 22
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "vaadin-route",
+          "mixins": [
+            "Vaadin.RouterMixin",
+            "Polymer.PropertiesMixin"
+          ]
+        },
+        {
+          "description": "`<vaadin-router-link>` is a Web Component that defines an in-app link. It is similar to\nan `<a>` tag but changes the URL without reloading the browser page. It uses the HTML5\nHistory API.\n\n```\n<vaadin-router-link href=\"/users/sam\">See Sam's profile</vaadin-router-link>\n```",
+          "summary": "",
+          "path": "vaadin-router-link.html",
+          "properties": [
+            {
+              "name": "router",
+              "type": "{pathname: string}",
+              "description": "Exposes the current path of the Vaadin Router",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "vaadin-router-mixin.html",
+                "start": {
+                  "line": 38,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.RouterMixin"
+            },
+            {
+              "name": "href",
+              "type": "string",
+              "description": "Contains a URL or a URL fragment that the link points to",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 57,
+                  "column": 10
+                },
+                "end": {
+                  "line": 57,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "active",
+              "type": "boolean",
+              "description": "Whether or not the route this link points to is currently active.\n\n(reflected to the `active` attribute)",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 64,
+                  "column": 10
+                },
+                "end": {
+                  "line": 64,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 68,
+                  "column": 6
+                },
+                "end": {
+                  "line": 77,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 79,
+                  "column": 6
+                },
+                "end": {
+                  "line": 81,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_onPopstate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 110,
+                  "column": 6
+                },
+                "end": {
+                  "line": 113,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_createPropertyAccessor",
+              "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 106,
+                  "column": 8
+                },
+                "end": {
+                  "line": 115,
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3520,109 +1291,32 @@
                 {
                   "name": "property",
                   "type": "string",
-                  "description": "Property that should trigger the effect"
+                  "description": "Name of the property"
                 },
                 {
-                  "name": "type",
-                  "type": "string",
-                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-                },
-                {
-                  "name": "effect",
-                  "type": "Object=",
-                  "description": "Effect metadata object"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "createPropertyObserver",
-              "description": "Creates a single-property observer for the given property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2226,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2228,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                },
-                {
-                  "name": "method",
-                  "type": "(string | function (*, *))",
-                  "description": "Function or name of observer method to call"
-                },
-                {
-                  "name": "dynamicFn",
+                  "name": "readOnly",
                   "type": "boolean=",
-                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                  "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
                 }
               ],
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "createMethodObserver",
-              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "name": "_addPropertyToAttributeMap",
+              "description": "Adds the given `property` to a map matching attribute names\nto property names, using `attributeNameForProperty`. This map is\nused when deserializing attribute values to properties.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 2243,
-                  "column": 6
+                  "line": 124,
+                  "column": 8
                 },
                 "end": {
-                  "line": 2245,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "expression",
-                  "type": "string",
-                  "description": "Method expression"
-                },
-                {
-                  "name": "dynamicFn",
-                  "type": "(boolean | Object)=",
-                  "description": "Boolean or object map indicating"
-                }
-              ],
-              "return": {
-                "type": "void",
-                "desc": "whether method names should be included as a dependency to the effect."
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "createNotifyingProperty",
-              "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2255,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2257,
-                  "column": 7
+                  "line": 132,
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3630,27 +1324,24 @@
                 {
                   "name": "property",
                   "type": "string",
-                  "description": "Property name"
+                  "description": "Name of the property"
                 }
               ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "createReadOnlyProperty",
-              "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+              "name": "_definePropertyAccessor",
+              "description": "Defines a property accessor for the given property.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 2275,
-                  "column": 6
+                  "line": 140,
+                  "column": 9
                 },
                 "end": {
-                  "line": 2277,
-                  "column": 7
+                  "line": 153,
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3658,239 +1349,736 @@
                 {
                   "name": "property",
                   "type": "string",
-                  "description": "Property name"
+                  "description": "Name of the property"
                 },
                 {
-                  "name": "protectedSetter",
+                  "name": "readOnly",
                   "type": "boolean=",
-                  "description": "Creates a custom protected setter\n  when `true`."
+                  "description": "When true, no setter is created"
                 }
               ],
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "createReflectedProperty",
-              "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
-              "privacy": "protected",
+              "name": "ready",
+              "description": "Lifecycle callback called when properties are enabled via\n`_enableProperties`.\n\nUsers may override this function to implement behavior that is\ndependent on the element having its property data initialized, e.g.\nfrom defaults (initialized from `constructor`, `_initializeProperties`),\n`attributeChangedCallback`, or values propagated from host e.g. via\nbindings.  `super.ready()` must be called to ensure the data system\nbecomes enabled.",
+              "privacy": "public",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 2287,
-                  "column": 6
+                  "line": 182,
+                  "column": 8
                 },
                 "end": {
-                  "line": 2289,
-                  "column": 7
+                  "line": 185,
+                  "column": 9
                 }
               },
               "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Property name"
-                }
-              ],
+              "params": [],
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesChanged"
             },
             {
-              "name": "createComputedProperty",
-              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "name": "_initializeProperties",
+              "description": "Overrides `PropertiesChanged` method and adds a call to\n`finalize` which lazily configures the element's property accessors.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 2305,
+                  "line": 191,
                   "column": 6
                 },
                 "end": {
-                  "line": 2307,
+                  "line": 194,
                   "column": 7
                 }
               },
               "metadata": {},
-              "params": [
-                {
-                  "name": "property",
-                  "type": "string",
-                  "description": "Name of computed property to set"
-                },
-                {
-                  "name": "expression",
-                  "type": "string",
-                  "description": "Method expression"
-                },
-                {
-                  "name": "dynamicFn",
-                  "type": "(boolean | Object)=",
-                  "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
-                }
-              ],
+              "params": [],
               "return": {
                 "type": "void"
               },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesMixin"
             },
             {
-              "name": "bindTemplate",
-              "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+              "name": "_initializeInstanceProperties",
+              "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
                 "start": {
-                  "line": 2321,
-                  "column": 6
+                  "line": 222,
+                  "column": 8
                 },
                 "end": {
-                  "line": 2323,
-                  "column": 7
+                  "line": 224,
+                  "column": 9
                 }
               },
               "metadata": {},
               "params": [
-                {
-                  "name": "template",
-                  "type": "!HTMLTemplateElement",
-                  "description": "Template containing binding\n  bindings"
-                }
-              ],
-              "return": {
-                "type": "!TemplateInfo",
-                "desc": "Template metadata object"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_addTemplatePropertyEffect",
-              "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2387,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2393,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "templateInfo",
-                  "type": "Object",
-                  "description": "Template metadata to add effect to"
-                },
-                {
-                  "name": "prop",
-                  "type": "string",
-                  "description": "Property that should trigger the effect"
-                },
-                {
-                  "name": "effect",
-                  "type": "Object=",
-                  "description": "Effect metadata object"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_parseBindings",
-              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2623,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2688,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "text",
-                  "type": "string",
-                  "description": "Text to parse from attribute or textContent"
-                },
-                {
-                  "name": "templateInfo",
-                  "type": "Object",
-                  "description": "Current template metadata"
-                }
-              ],
-              "return": {
-                "type": "Array.<!BindingPart>",
-                "desc": "Array of binding part metadata"
-              },
-              "inheritedFrom": "Polymer.PropertyEffects"
-            },
-            {
-              "name": "_evaluateBinding",
-              "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/property-effects.html",
-                "start": {
-                  "line": 2704,
-                  "column": 6
-                },
-                "end": {
-                  "line": 2721,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "inst",
-                  "type": "this",
-                  "description": "Element that should be used as scope for\n  binding dependencies"
-                },
-                {
-                  "name": "part",
-                  "type": "BindingPart",
-                  "description": "Binding part metadata"
-                },
-                {
-                  "name": "path",
-                  "type": "string",
-                  "description": "Property/path that triggered this effect"
-                },
                 {
                   "name": "props",
                   "type": "Object",
-                  "description": "Bag of current property changes"
+                  "description": "Bag of property values that were overwritten\n  when creating property accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setProperty",
+              "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 235,
+                  "column": 8
+                },
+                "end": {
+                  "line": 239,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
                 },
                 {
-                  "name": "oldProps",
-                  "type": "Object",
-                  "description": "Bag of previous values for changed properties"
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_getProperty",
+              "description": "Returns the value for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 247,
+                  "column": 8
                 },
+                "end": {
+                  "line": 249,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
                 {
-                  "name": "hasPaths",
-                  "type": "boolean",
-                  "description": "True with `props` contains one or more paths"
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of property"
                 }
               ],
               "return": {
                 "type": "*",
-                "desc": "Value the binding part evaluated to"
+                "desc": "Value for the given property"
               },
-              "inheritedFrom": "Polymer.PropertyEffects"
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setPendingProperty",
+              "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 264,
+                  "column": 8
+                },
+                "end": {
+                  "line": 280,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "ext",
+                  "type": "boolean=",
+                  "description": "Not used here; affordance for closure"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property changed"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_invalidateProperties",
+              "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 290,
+                  "column": 8
+                },
+                "end": {
+                  "line": 300,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_enableProperties",
+              "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 313,
+                  "column": 8
+                },
+                "end": {
+                  "line": 322,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_flushProperties",
+              "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 333,
+                  "column": 8
+                },
+                "end": {
+                  "line": 342,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_shouldPropertiesChange",
+              "description": "Called in `_flushProperties` to determine if `_propertiesChanged`\nshould be called. The default implementation returns true if\nproperties are pending. Override to customize when\n`_propertiesChanged` is called.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 356,
+                  "column": 8
+                },
+                "end": {
+                  "line": 358,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "true if changedProps is truthy"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "(override of `Polymer.PropertiesChanged._propertiesChanged)\n\nCallback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 97,
+                  "column": 6
+                },
+                "end": {
+                  "line": 108,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              }
+            },
+            {
+              "name": "_shouldPropertyChange",
+              "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 393,
+                  "column": 8
+                },
+                "end": {
+                  "line": 400,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "New property value"
+                },
+                {
+                  "name": "old",
+                  "type": "*",
+                  "description": "Previous property value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeChangedCallback",
+              "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 412,
+                  "column": 8
+                },
+                "end": {
+                  "line": 419,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of attribute that changed"
+                },
+                {
+                  "name": "old",
+                  "type": "?string",
+                  "description": "Old attribute value"
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "New attribute value"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_attributeToProperty",
+              "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 433,
+                  "column": 8
+                },
+                "end": {
+                  "line": 440,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to deserialize."
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "of the attribute."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertyToAttribute",
+              "description": "Serializes a property to its associated attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 452,
+                  "column": 8
+                },
+                "end": {
+                  "line": 458,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name to reflect."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string=",
+                  "description": "Attribute name to reflect to."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Property value to refect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_valueToNodeAttribute",
+              "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 473,
+                  "column": 8
+                },
+                "end": {
+                  "line": 480,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Element to set attribute to."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to serialize."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Attribute name to serialize to."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_serializeValue",
+              "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 493,
+                  "column": 8
+                },
+                "end": {
+                  "line": 500,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Property value to serialize."
+                }
+              ],
+              "return": {
+                "type": "(string | undefined)",
+                "desc": "String serialized from the provided\nproperty  value."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_deserializeValue",
+              "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 514,
+                  "column": 8
+                },
+                "end": {
+                  "line": 523,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "Value to deserialize."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "Type to deserialize the string to."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Typed value deserialized from the provided string."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_onHrefChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 115,
+                  "column": 6
+                },
+                "end": {
+                  "line": 119,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "newValue"
+                },
+                {
+                  "name": "oldValue"
+                }
+              ]
+            },
+            {
+              "name": "_onActiveCriteriaChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 121,
+                  "column": 6
+                },
+                "end": {
+                  "line": 123,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_onClick",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 125,
+                  "column": 6
+                },
+                "end": {
+                  "line": 129,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "createProperties",
+              "description": "Creates property accessors for the given property names.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 66,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "!Object",
+                  "description": "Object whose keys are names of accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeNameForProperty",
+              "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 77,
+                  "column": 8
+                },
+                "end": {
+                  "line": 79,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property to convert"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Attribute name corresponding to the given property."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "typeForProperty",
+              "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 180,
+                  "column": 6
+                },
+                "end": {
+                  "line": 183,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Type to which to deserialize attribute"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
             },
             {
               "name": "finalize",
@@ -3916,122 +2104,110 @@
             },
             {
               "name": "_finalizeClass",
-              "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+              "description": "Finalize an element class. This includes ensuring property\naccessors exist on the element prototype. This method is called by\n`finalize` and finalizes the class constructor.",
               "privacy": "protected",
               "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
                 "start": {
-                  "line": 293,
-                  "column": 5
+                  "line": 146,
+                  "column": 6
                 },
                 "end": {
-                  "line": 316,
+                  "line": 151,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "createObservers",
-              "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 342,
-                  "column": 6
-                },
-                "end": {
-                  "line": 347,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "observers",
-                  "type": "Object",
-                  "description": "Array of observer descriptors for\n  this class"
-                },
-                {
-                  "name": "dynamicFns",
-                  "type": "Object",
-                  "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "_processStyleText",
-              "description": "Gather style text for a style element in the template.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 490,
-                  "column": 6
-                },
-                "end": {
-                  "line": 492,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "cssText",
-                  "type": "string",
-                  "description": "Text containing styling to process"
-                },
-                {
-                  "name": "baseURI",
-                  "type": "string",
-                  "description": "Base URI to rebase CSS paths against"
-                }
-              ],
-              "return": {
-                "type": "string",
-                "desc": "The processed CSS text"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
-            },
-            {
-              "name": "_finalizeTemplate",
-              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
-                "start": {
-                  "line": 503,
-                  "column": 6
-                },
-                "end": {
-                  "line": 514,
-                  "column": 7
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "is",
-                  "type": "string",
-                  "description": "Tag name (or type extension name) for this element"
-                }
-              ],
-              "return": {
-                "type": "void"
-              },
-              "inheritedFrom": "Polymer.ElementMixin"
+              "inheritedFrom": "Polymer.PropertiesMixin"
             }
           ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 49,
+              "column": 4
+            },
+            "end": {
+              "line": 130,
+              "column": 5
+            }
+          },
+          "privacy": "public",
+          "superclass": "HTMLElement",
+          "name": "Vaadin.RouterLinkElement",
+          "attributes": [
+            {
+              "name": "router",
+              "description": "Exposes the current path of the Vaadin Router",
+              "sourceRange": {
+                "file": "vaadin-router-mixin.html",
+                "start": {
+                  "line": 38,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 22
+                }
+              },
+              "metadata": {},
+              "type": "{pathname: string}",
+              "inheritedFrom": "Vaadin.RouterMixin"
+            },
+            {
+              "name": "href",
+              "description": "Contains a URL or a URL fragment that the link points to",
+              "sourceRange": {
+                "start": {
+                  "line": 57,
+                  "column": 10
+                },
+                "end": {
+                  "line": 57,
+                  "column": 22
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "active",
+              "description": "Whether or not the route this link points to is currently active.\n\n(reflected to the `active` attribute)",
+              "sourceRange": {
+                "start": {
+                  "line": 64,
+                  "column": 10
+                },
+                "end": {
+                  "line": 64,
+                  "column": 25
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "vaadin-router-link",
+          "mixins": [
+            "Vaadin.RouterMixin",
+            "Polymer.PropertiesMixin"
+          ]
+        },
+        {
+          "description": "`<vaadin-router>` is a Web Component that renders different content for different URLs. This\nenables client-side routing. Each content alternative is defined with a `<vaadin-route>` component:\n\n```\n<vaadin-router>\n  <vaadin-route path=\"/users\">\n    <x-user-list></x-user-list>\n  </vaadin-route>\n  <vaadin-route path=\"/users/:user\">\n    <x-user-profile></x-user-profile>\n  </vaadin-route>\n</vaadin-router>\n```",
+          "summary": "",
+          "path": "vaadin-router.html",
+          "properties": [],
+          "methods": [],
+          "staticMethods": [],
           "demos": [
             {
               "url": "demo/",
@@ -4041,62 +2217,46 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 35,
-              "column": 6
+              "line": 28,
+              "column": 4
             },
             "end": {
-              "line": 44,
-              "column": 7
+              "line": 32,
+              "column": 5
             }
           },
           "privacy": "public",
-          "superclass": "Polymer.Element",
-          "name": "Vaadin.VaadinRouter",
+          "superclass": "HTMLElement",
+          "name": "Vaadin.RouterElement",
           "attributes": [],
           "events": [],
           "styling": {
             "cssVariables": [],
             "selectors": []
           },
-          "slots": [
-            {
-              "description": "",
-              "name": "",
-              "range": {
-                "file": "vaadin-router.html",
-                "start": {
-                  "line": 19,
-                  "column": 4
-                },
-                "end": {
-                  "line": 19,
-                  "column": 17
-                }
-              }
-            }
-          ],
+          "slots": [],
           "tagname": "vaadin-router"
         }
       ],
       "mixins": [
         {
-          "description": "",
+          "description": "Subscribes an element to the 'popstate' event on the current window, and\ninjects the `router` property (a reference to the Vaadin Router).\n\nThe users of this mixin should override the `_onPopstate` method to\nhandle the event. Remember to call `super._onPopstate` in the override:\n```\n_onPopstate(event) {\n  super._onPopstate(event);\n\n  // do your stuff here\n}\n```",
           "summary": "",
           "path": "vaadin-router-mixin.html",
           "properties": [
             {
               "name": "router",
-              "type": "Object",
-              "description": "",
+              "type": "{pathname: string}",
+              "description": "Exposes the current path of the Vaadin Router",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 16,
+                  "line": 38,
                   "column": 8
                 },
                 "end": {
-                  "line": 21,
-                  "column": 9
+                  "line": 38,
+                  "column": 22
                 }
               },
               "metadata": {
@@ -4111,11 +2271,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 30,
+                  "line": 47,
                   "column": 4
                 },
                 "end": {
-                  "line": 33,
+                  "line": 53,
                   "column": 5
                 }
               },
@@ -4128,11 +2288,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 35,
+                  "line": 55,
                   "column": 4
                 },
                 "end": {
-                  "line": 38,
+                  "line": 58,
                   "column": 5
                 }
               },
@@ -4140,25 +2300,30 @@
               "params": []
             },
             {
-              "name": "__onPopstate",
-              "description": "",
-              "privacy": "private",
+              "name": "_onPopstate",
+              "description": "Callback called when the 'popstate' event is triggered on the window.",
+              "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 40,
+                  "line": 67,
                   "column": 4
                 },
                 "end": {
-                  "line": 42,
+                  "line": 73,
                   "column": 5
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "event"
+                  "name": "event",
+                  "type": "!Object",
+                  "description": "the popstate event"
                 }
-              ]
+              ],
+              "return": {
+                "type": "void"
+              }
             }
           ],
           "staticMethods": [],
@@ -4166,11 +2331,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 13,
+              "line": 30,
               "column": 2
             },
             "end": {
-              "line": 43,
+              "line": 74,
               "column": 3
             }
           },
@@ -4179,19 +2344,19 @@
           "attributes": [
             {
               "name": "router",
-              "description": "",
+              "description": "Exposes the current path of the Vaadin Router",
               "sourceRange": {
                 "start": {
-                  "line": 16,
+                  "line": 38,
                   "column": 8
                 },
                 "end": {
-                  "line": 21,
-                  "column": 9
+                  "line": 38,
+                  "column": 22
                 }
               },
               "metadata": {},
-              "type": "Object"
+              "type": "{pathname: string}"
             }
           ],
           "events": [],

--- a/vaadin-route.html
+++ b/vaadin-route.html
@@ -15,22 +15,31 @@ This program is available under Apache License Version 2.0, available at https:/
   (function() {
 
     /**
-     * `<vaadin-route>` is a Polymer 2 element.
+     * `<vaadin-route>` is a Web Component that defines a single route for the
+     * `<vaadin-router>` component.
      *
      * ```
-     * <vaadin-route></vaadin-route>
+     * <vaadin-route path="/users/:user">
+     *   <x-user-view></x-user-view>
+     * </vaadin-route>
      * ```
      *
+     * @polymer
+     * @customElement
      * @memberof Vaadin
+     * @appliesMixin Vaadin.RouterMixin
+     * @appliesMixin Polymer.PropertiesMixin
      */
-    class VaadinRoute extends Vaadin.RouterMixin(Polymer.PropertiesMixin(HTMLElement)) {
+    class RouteElement extends Vaadin.RouterMixin(Polymer.PropertiesMixin(HTMLElement)) {
       static get is() {
         return 'vaadin-route';
       }
 
       static get properties() {
         return {
+          /** Defines the path served by this route */
           path: String,
+
           _parameters: Array,
           _regexp: Object,
           _routeTemplate: Object,
@@ -54,6 +63,8 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       /**
+       * (override of `Polymer.PropertiesChanged._propertiesChanged)
+       * 
        * Callback called when any properties with accessors created via
        * `_createPropertyAccessor` have been set.
        *
@@ -131,12 +142,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    customElements.define(VaadinRoute.is, VaadinRoute);
+    customElements.define(RouteElement.is, RouteElement);
 
     /**
      * @namespace Vaadin
      */
     window.Vaadin = window.Vaadin || {};
-    Vaadin.VaadinRoute = VaadinRoute;
+    Vaadin.RouteElement = RouteElement;
   })();
 </script>

--- a/vaadin-router-link.html
+++ b/vaadin-router-link.html
@@ -33,16 +33,35 @@ This program is available under Apache License Version 2.0, available at https:/
     const template = document.currentScript.ownerDocument.querySelector('template');
 
     /**
-      * @memberof Vaadin
-      */
-    class VaadinRouterLink extends Vaadin.RouterMixin(Polymer.PropertiesMixin(HTMLElement)) {
+     * `<vaadin-router-link>` is a Web Component that defines an in-app link. It is similar to
+     * an `<a>` tag but changes the URL without reloading the browser page. It uses the HTML5
+     * History API.
+     *
+     * ```
+     * <vaadin-router-link href="/users/sam">See Sam's profile</vaadin-router-link>
+     * ```
+     *
+     * @polymer
+     * @customElement
+     * @memberof Vaadin
+     * @appliesMixin Vaadin.RouterMixin
+     * @appliesMixin Polymer.PropertiesMixin
+     */
+    class RouterLinkElement extends Vaadin.RouterMixin(Polymer.PropertiesMixin(HTMLElement)) {
       static get is() {
         return 'vaadin-router-link';
       }
 
       static get properties() {
         return {
+          /** Contains a URL or a URL fragment that the link points to */
           href: String,
+
+          /**
+           * Whether or not the route this link points to is currently active.
+           * 
+           * (reflected to the `active` attribute)
+           */
           active: Boolean
         };
       }
@@ -63,17 +82,19 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       /**
-        * Callback called when any properties with accessors created via
-        * `_createPropertyAccessor` have been set.
-        *
-        * @param {!Object} currentProps Bag of all current accessor values
-        * @param {!Object} changedProps Bag of properties changed since the last
-        *   call to `_propertiesChanged`
-        * @param {!Object} oldProps Bag of previous values for each property
-        *   in `changedProps`
-        * @return {void}
-        * @protected
-        */
+       * (override of `Polymer.PropertiesChanged._propertiesChanged)
+       * 
+       * Callback called when any properties with accessors created via
+       * `_createPropertyAccessor` have been set.
+       *
+       * @param {!Object} currentProps Bag of all current accessor values
+       * @param {!Object} changedProps Bag of properties changed since the last
+       *   call to `_propertiesChanged`
+       * @param {!Object} oldProps Bag of previous values for each property
+       *   in `changedProps`
+       * @return {void}
+       * @protected
+       */
       _propertiesChanged(currentProps, changedProps, oldProps) {
         super._propertiesChanged(currentProps, changedProps, oldProps);
 
@@ -109,12 +130,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    customElements.define(VaadinRouterLink.is, VaadinRouterLink);
+    customElements.define(RouterLinkElement.is, RouterLinkElement);
 
     /**
       * @namespace Vaadin
       */
     window.Vaadin = window.Vaadin || {};
-    Vaadin.VaadinRouterLink = VaadinRouterLink;
+    Vaadin.RouterLinkElement = RouterLinkElement;
   })();
 </script>

--- a/vaadin-router-mixin.html
+++ b/vaadin-router-mixin.html
@@ -6,14 +6,36 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <script>
 (() => {
+  /**
+   * @namespace Vaadin
+   */
   window.Vaadin = window.Vaadin || {};
 
   /**
-   * @polymerMixin
+   * Subscribes an element to the 'popstate' event on the current window, and
+   * injects the `router` property (a reference to the Vaadin Router).
+   * 
+   * The users of this mixin should override the `_onPopstate` method to
+   * handle the event. Remember to call `super._onPopstate` in the override:
+   * ```
+   * _onPopstate(event) {
+   *   super._onPopstate(event);
+   * 
+   *   // do your stuff here
+   * }
+   * ```
+   * 
+   * @polymer
+   * @mixinFunction
    */
-  Vaadin.RouterMixin = superClass => class VaadinRouterMixin extends superClass {
+  Vaadin.RouterMixin = superClass => class extends superClass {
     static get properties() {
       return {
+        /**
+         * Exposes the current path of the Vaadin Router
+         *
+         * @type {{pathname: string}}
+         */
         router: Object
       };
     }
@@ -36,6 +58,13 @@ This program is available under Apache License Version 2.0, available at https:/
       super.disconnectedCallback();
     }
 
+    /**
+     * Callback called when the 'popstate' event is triggered on the window.
+     *
+     * @param {!Object} event the popstate event
+     * @return {void}
+     * @protected
+     */
     _onPopstate(event) {
       if (this.set) {
         this.set('router.pathname', window.location.pathname)

--- a/vaadin-router.html
+++ b/vaadin-router.html
@@ -8,21 +8,36 @@ This program is available under Apache License Version 2.0, available at https:/
   (function() {
 
     /**
+     * `<vaadin-router>` is a Web Component that renders different content for different URLs. This
+     * enables client-side routing. Each content alternative is defined with a `<vaadin-route>` component:
+     *
+     * ```
+     * <vaadin-router>
+     *   <vaadin-route path="/users">
+     *     <x-user-list></x-user-list>
+     *   </vaadin-route>
+     *   <vaadin-route path="/users/:user">
+     *     <x-user-profile></x-user-profile>
+     *   </vaadin-route>
+     * </vaadin-router>
+     * ```
+     * 
+     * @customElement
      * @memberof Vaadin
      * @demo demo/
      */
-    class VaadinRouter extends HTMLElement {
+    class RouterElement extends HTMLElement {
       static get is() {
         return 'vaadin-router';
       }
     }
 
-    customElements.define(VaadinRouter.is, VaadinRouter);
+    customElements.define(RouterElement.is, RouterElement);
 
     /**
      * @namespace Vaadin
      */
     window.Vaadin = window.Vaadin || {};
-    Vaadin.VaadinRouter = VaadinRouter;
+    Vaadin.RouterElement = RouterElement;
   })();
 </script>


### PR DESCRIPTION
The features of the Polymer 2 library that are still in use:
 - observe HTML attribute changes and deserialize JS property values out of them (and back from properties to attributes): `Polymer.PropertiesMixin`
- call an observer when a custom element's property changes: `Polymer.PropertiesChanged`
- inject route parameters into the inline route templates: `Polymer.Templatize`

The features of the Polymer 2 library that are not used anymore:
 - Polymer.PropertyEffects (via Polymer.Element): Was used for the 'value', 'reflectToAttribute' and 'observer' features of Polymer Element's properties. Now this is done manually based on the Polymer.Properties mixin.
 - Polymer.TemplateStamp (via Polymer.Element): Was used to create the shadow DOM of the vaadin-router-link element, bind data and event handler based on a template. Now this is done manually directly through the browser APIs.

Bundle size change
 - for polymer apps: +0.95 kB (8.61 kB -> 9.56 kB)
 - for non-polymer apps: -4.2 kB (57.7 kB -> 53.3 kB)