### PR TITLE
limit the Travis 'build on push' feature to the master branch only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
   firefox: latest
   chrome: stable
 
+# limit the Travis 'build on push' feature to the master branch only
+branches:
+  only:
+   - master
+
 script:
   - cd core
   - yarn lint


### PR DESCRIPTION
Without this setting each time a new commit is pushed to a PR branch Travis triggers two identical builds:
 - build on a PR
 - build on a push

This setting changes the behavior so that only one build is triggered. The downside is that pushes to non-PR branches would not trigger any builds at all (but with the current workflow such branches are rarely used).