### PR TITLE
Prevent duplicate navigation event for same pathname

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -258,9 +258,8 @@ export class Router extends Resolver {
   __updateBrowserHistory(pathnameOrContext) {
     const pathname = pathnameOrContext.pathname || pathnameOrContext;
     if (window.location.pathname !== pathname) {
-      const state = 'vaadin-router:ignore';
-      window.history.pushState(state, document.title, pathname);
-      window.dispatchEvent(new PopStateEvent('popstate', {state}));
+      window.history.pushState(null, document.title, pathname);
+      window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router:ignore'}));
     }
   }
 

--- a/src/router.js
+++ b/src/router.js
@@ -258,8 +258,9 @@ export class Router extends Resolver {
   __updateBrowserHistory(pathnameOrContext) {
     const pathname = pathnameOrContext.pathname || pathnameOrContext;
     if (window.location.pathname !== pathname) {
-      window.history.pushState(null, document.title, pathname);
-      window.dispatchEvent(new PopStateEvent('popstate'));
+      const state = 'vaadin-router:ignore';
+      window.history.pushState(state, document.title, pathname);
+      window.dispatchEvent(new PopStateEvent('popstate', {state}));
     }
   }
 

--- a/src/triggers/popstate.js
+++ b/src/triggers/popstate.js
@@ -7,13 +7,16 @@ if (isIE && typeof window.PopStateEvent !== 'function') {
   window.PopStateEvent = function(inType, params) {
     params = params || {};
     var e = document.createEvent('CustomEvent');
-    e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), params.detail);
+    e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), {state: params.state || null});
     return e;
   };
   window.PopStateEvent.prototype = window.Event.prototype;
 }
 
-function vaadinRouterGlobalPopstateHandler() {
+function vaadinRouterGlobalPopstateHandler(event) {
+  if (event.state === 'vaadin-router:ignore') {
+    return;
+  }
   triggerNavigation(window.location.pathname);
 }
 

--- a/src/triggers/popstate.js
+++ b/src/triggers/popstate.js
@@ -6,8 +6,9 @@ const isIE = /Trident/.test(navigator.userAgent);
 if (isIE && typeof window.PopStateEvent !== 'function') {
   window.PopStateEvent = function(inType, params) {
     params = params || {};
-    var e = document.createEvent('CustomEvent');
-    e.initCustomEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable), {state: params.state || null});
+    var e = document.createEvent('Event');
+    e.initEvent(inType, Boolean(params.bubbles), Boolean(params.cancelable));
+    e.state = params.state || null;
     return e;
   };
   window.PopStateEvent.prototype = window.Event.prototype;

--- a/test/router.spec.html
+++ b/test/router.spec.html
@@ -367,6 +367,15 @@
             expect(onpopstate).to.not.have.been.called;
           });
 
+          it('should fire navigate event only once per single pathname change', async() => {
+            const navigateSpy = sinon.spy();
+            window.addEventListener('vaadin-router:navigate', navigateSpy);
+            const event = new CustomEvent('vaadin-router:navigate', {detail: {pathname: '/admin'}});
+            window.dispatchEvent(event);
+            await router.ready;
+            expect(navigateSpy).to.be.calledOnce;
+          });
+
           it('should automatically subscribe to navigation events when created', async() => {
             window.dispatchEvent(new CustomEvent('vaadin-router:navigate', {detail: {pathname: '/'}}));
             await router.ready;


### PR DESCRIPTION
Fixes #89

Depends on #96 for the demo and tests (but not implementation)
- check "Custom Route Action" demo
- click the "All Users" link
- see the `Statistics on URL visits: { "/users": 1 }}`

Same results in `"/users": 2` when running fix on top of the master, most likely because of the fact that `triggerNavigation.js` is bundled into two different locations at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/98)
<!-- Reviewable:end -->
