### PR TITLE
Fix catching DOMException: do not override read only code property

### DIFF
--- a/src/resolver/resolver.js
+++ b/src/resolver/resolver.js
@@ -44,7 +44,7 @@ class Resolver {
    * Returns the current list of routes (as a shallow copy). Adding / removing
    * routes to / from the returned array does not affect the routing config,
    * but modifying the route objects does.
-   * 
+   *
    * @return {!Array<!Route>}
    */
   getRoutes() {
@@ -53,7 +53,7 @@ class Resolver {
 
   /**
    * Sets the routing config (replacing the existing one).
-   * 
+   *
    * @param {!Array<!Route>|!Route} routes a single route or an array of those
    *    (the array is shallow copied)
    */
@@ -65,7 +65,7 @@ class Resolver {
   /**
    * Appends one or several routes to the routing config and returns the
    * effective routing config after the operation.
-   * 
+   *
    * @param {!Array<!Route>|!Route} routes a single route or an array of those
    *    (the array is shallow copied)
    * @return {!Array<!Route>}
@@ -80,14 +80,14 @@ class Resolver {
    * Asynchronously resolves the given pathname, i.e. finds all routes matching
    * the pathname and tries resolving them one after another in the order they
    * are listed in the routes config until the first non-null result.
-   * 
+   *
    * Returns a promise that is fulfilled with the return value of the first
    * route handler that returns something other than `null` or `undefined`.
-   * 
+   *
    * If no route handlers return a non-null result, or if no route matches the
    * given pathname the returned promise is rejected with a 'page not found'
    * `Error`.
-   * 
+   *
    * @param {!string|!{pathname: !string}} pathnameOrContext the pathname to
    *    resolve or a context object with a `pathname` property and other
    *    properties to pass to the route resolver functions.
@@ -143,7 +143,10 @@ class Resolver {
       .then(() => next(true, this.root))
       .catch((error) => {
         error.context = error.context || currentContext;
-        error.code = error.code || 500;
+        // DOMException has its own code which is read-only
+        if (!(error instanceof DOMException)) {
+          error.code = error.code || 500;
+        }
         if (this.errorHandler) {
           return this.errorHandler(error);
         }

--- a/test/router.spec.html
+++ b/test/router.spec.html
@@ -152,6 +152,17 @@
             expect(outlet.children[0].tagName).to.match(/x-home-view/i);
           });
 
+          it('should rethrow DOMException if the route `component` is not a valid tag name', async() => {
+            router.setRoutes([{path: '/', component: 'src/x-home-view'}]);
+            const fulfilled = sinon.spy();
+            const rejected = sinon.spy();
+            const ready = router.render('/').then(fulfilled).catch(rejected);
+            await ready;
+            expect(fulfilled).to.not.have.been.called;
+            expect(rejected).to.have.been.called.once;
+            expect(rejected.args[0][0]).to.be.instanceof(DOMException);
+          });
+
           it('should replace any pre-existing content of the router outlet', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},


### PR DESCRIPTION
Currently, setting route `component` to something that is not a valid tag name, e. g. `src/x-home-view.html` throws the following error:

```
TypeError: Cannot assign to read only property 'code' of object ''
```
This happens because [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) has its own, legacy `code` property which is read only.

That error is quite confusing. As a developer, I expect the exception to look like this:

```
Uncaught (in promise) DOMException: Failed to execute 'createElement' on 'Document': The tag name provided ('src/x-home-view.html') is not a valid name.
```

Added a check and a test ensuring we rethrow the exception correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/99)
<!-- Reviewable:end -->
