### PR TITLE
Improve the same origin link detection

### DIFF
--- a/src/triggers/click.js
+++ b/src/triggers/click.js
@@ -1,5 +1,6 @@
 import triggerNavigation from './triggerNavigation.js';
 
+/* istanbul ignore next: coverage is calculated in Chrome, this code is for IE */
 function getAnchorOrigin(anchor) {
   // IE11: on HTTP and HTTPS the default port is not included into
   // window.location.origin, so won't include it here either.

--- a/src/triggers/click.js
+++ b/src/triggers/click.js
@@ -8,8 +8,8 @@ function getAnchorOrigin(anchor) {
   const defaultHttp = protocol === 'http:' && port === '80';
   const defaultHttps = protocol === 'https:' && port === '443';
   const host = (defaultHttp || defaultHttps)
-    ? anchor.hostname
-    : anchor.host;
+    ? anchor.hostname // does not include the port number (e.g. www.example.org)
+    : anchor.host; // does include the port number (e.g. www.example.org:80)
   return `${protocol}//${host}`;
 }
 

--- a/src/triggers/click.js
+++ b/src/triggers/click.js
@@ -1,5 +1,18 @@
 import triggerNavigation from './triggerNavigation.js';
 
+function getAnchorOrigin(anchor) {
+  // IE11: on HTTP and HTTPS the default port is not included into
+  // window.location.origin, so won't include it here either.
+  const port = anchor.port;
+  const protocol = anchor.protocol;
+  const defaultHttp = protocol === 'http:' && port === '80';
+  const defaultHttps = protocol === 'https:' && port === '443';
+  const host = (defaultHttp || defaultHttps)
+    ? anchor.hostname
+    : anchor.host;
+  return `${protocol}//${host}`;
+}
+
 // The list of checks is not complete:
 //  - SVG support is missing
 //  - the 'rel' attribute is not considered
@@ -54,16 +67,15 @@ function vaadinRouterGlobalClickHandler(event) {
     return;
   }
 
-  // IE11 does not have document.baseURI
-  const baseURI = document.baseURI || (document.querySelector('base') || window.location).href;
-
-  // ignore the click if the target URL is external to the app
-  if (!(anchor.href.indexOf(baseURI) === 0)) {
+  // ignore the click if the target URL is a fragment on the current page
+  if (anchor.pathname === window.location.pathname && anchor.hash !== '') {
     return;
   }
 
-  // ignore the click if the target URL is a fragment on the current page
-  if (anchor.pathname === window.location.pathname && anchor.hash !== '') {
+  // ignore the click if the target is external to the app
+  // In IE11 HTMLAnchorElement does not have the `origin` property
+  const origin = anchor.origin || getAnchorOrigin(anchor);
+  if (origin !== window.location.origin) {
     return;
   }
 

--- a/src/triggers/popstate.js
+++ b/src/triggers/popstate.js
@@ -3,6 +3,7 @@ import triggerNavigation from './triggerNavigation.js';
 // PopStateEvent constructor shim
 const isIE = /Trident/.test(navigator.userAgent);
 
+/* istanbul ignore next: coverage is calculated in Chrome, this code is for IE */
 if (isIE && typeof window.PopStateEvent !== 'function') {
   window.PopStateEvent = function(inType, params) {
     params = params || {};

--- a/test/router.spec.html
+++ b/test/router.spec.html
@@ -9,6 +9,7 @@
 </head>
 
 <body>
+  <a id="admin-anchor" href="/admin"></a>
   <test-fixture id="outlet">
     <template>
       <div></div>
@@ -447,9 +448,7 @@
           });
 
           it('should use the CLICK navigation trigger by default', async() => {
-            const link = document.createElement('a');
-            link.setAttribute('href', '/admin');
-            outlet.children[0].appendChild(link);
+            const link = document.getElementById('admin-anchor');
             link.click();
             await router.ready;
             expect(outlet.children).to.have.lengthOf(1);

--- a/test/triggers/click.spec.html
+++ b/test/triggers/click.spec.html
@@ -13,6 +13,7 @@
 
 <body>
   <div>
+    <a id="home" href="">home</a>
     <a id="in-app" href="in-app/link">in-app/link</a>
     <a href="in-app/link">
       <span id="text-in-a-link">not a link (inside a link)</span>
@@ -25,6 +26,7 @@
     <a id="in-app-target-blank" target="_blank" href="in-app/link">in-app/link (target="_blank")</a>
     <a id="in-app-download" download href="in-app/link">in-app/link (download)</a>
     <a id="external" href="http://example.com/in-app/link">http://example.com/in-app/link</a>
+    <a id="cross-origin" href="[same domain, different port]">[same domain, different port]</a>
     <div id="shadow-host-with-a-link" class="shadow-host">
       <template>
         <a id="in-app-in-a-shadow" href="in-app/link">in-app/link (inside a shadow DOM)</a>
@@ -39,8 +41,17 @@
 
   <script>
     window.addEventListener('WebComponentsReady', () => {
+      (function setupCrossOriginLink() {
+        const origin = window.location.protocol + '//'
+          + window.location.hostname + ':'
+          + (parseInt(window.location.port) + 1);
+        document.getElementById('cross-origin')
+          .setAttribute('href', `${origin}/in-app`);
+      })();
+
       (function setupInPageHashLink() {
-        document.getElementById('in-page-hash-link').setAttribute('href', window.location.pathname + '#in-page');
+        document.getElementById('in-page-hash-link')
+          .setAttribute('href', window.location.pathname + '#in-page');
       })();
 
       (function setupShadowRoots() {
@@ -211,6 +222,20 @@
             expect(clicks[0]).to.have.property('defaultPrevented', true);
           });
 
+          it('should work for navigation from /deep/pages/in/app to /', () => {
+            const location = window.location.pathname;
+            window.history.replaceState(null, document.title, '/deep/page/in/app');
+            emulateClick(document.getElementById('home'));
+            window.history.replaceState(null, document.title, location);
+
+            expect(navigateEvents).to.have.lengthOf(1);
+            expect(navigateEvents[0]).to.have.property('type', 'vaadin-router:navigate');
+            expect(navigateEvents[0]).to.have.deep.property('detail.pathname', '/');
+
+            expect(clicks).to.have.lengthOf(1);
+            expect(clicks[0]).to.have.property('defaultPrevented', true);
+          });
+
           describe('irrelevant `click` events', () => {
             function expectClickIgnored() {
               expect(navigateEvents).to.have.lengthOf(0);
@@ -265,6 +290,11 @@
 
             it('should ignore `click` events on external links', () => {
               emulateClick(document.getElementById('external'));
+              expectClickIgnored();
+            });
+
+            it('should ignore `click` events on cross-origin links', () => {
+              emulateClick(document.getElementById('cross-origin'));
               expectClickIgnored();
             });
 

--- a/test/triggers/popstate.spec.js
+++ b/test/triggers/popstate.spec.js
@@ -27,6 +27,17 @@
       expect(spy.args[0][0]).to.have.deep.property('detail.pathname', '/test-url');
     });
 
+    it('should ignore `popstate` events with the `vaadin-router:ignore` state', () => {
+      POPSTATE.inactivate();
+      const spy = sinon.spy();
+      window.addEventListener('vaadin-router:navigate', spy);
+      POPSTATE.activate();
+      window.history.pushState(null, null, '/test-url');
+      window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router:ignore'}));
+      window.removeEventListener('vaadin-router:navigate', spy);
+      expect(spy).to.not.have.been.called;
+    });
+
     it('should not translate `popstate` events into `vaadin-router:navigate` when inactivated', () => {
       POPSTATE.activate();
       POPSTATE.inactivate();


### PR DESCRIPTION
Improve the same origin check on `<a>` in-app links.

Fixes #87

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/101)
<!-- Reviewable:end -->
