### PR TITLE
enable better minification with uglify-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --ext .html,.js src test demo *.js *.html",
     "lint:css": "stylelint demo/**/*.html",
-    "build": "rollup -c && uglifyjs dist/umd/vaadin-router.js --source-map --output dist/umd/vaadin-router.min.js",
+    "build": "rollup -c && uglifyjs dist/umd/vaadin-router.js -c -m --mangle-props regex=/^__/ --source-map --output dist/umd/vaadin-router.min.js",
     "build:watch": "rollup -c -w",
     "start": "polymer serve --port 8000",
     "start:browser-sync": "browser-sync start --config bs-config.js",


### PR DESCRIPTION
 - turn on compression and names mangling (consider all properties starting with a double underscore private and mangle them)
 - bundle size minified gzipped: 4.31 kB (was 5.44 kB)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/110)
<!-- Reviewable:end -->
