### PR TITLE
update demo descriptions, reorder tabs 

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -7,7 +7,7 @@ module.exports = {
     'analysis.json'
   ],
   snippetOptions: {
-    blacklist: [
+    ignorePaths: [
       '**/demo/iframe.html'
     ]
   }

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,7 +2,7 @@
   "name": "Vaadin.Router",
   "pages": [
     {
-      "name": "Basic",
+      "name": "Getting Started",
       "url": "vaadin-router-basic-demos",
       "src": "vaadin-router-basic-demos.html",
       "meta": {
@@ -22,11 +22,21 @@
       }
     },
     {
-      "name": "Navigation Triggers",
-      "url": "vaadin-router-navigation-trigger-demos",
-      "src": "vaadin-router-navigation-trigger-demos.html",
+      "name": "Redirects",
+      "url": "vaadin-router-redirect-demos",
+      "src": "vaadin-router-redirect-demos.html",
       "meta": {
-        "title": "Vaadin.Router Navigation Trigger Examples",
+        "title": "Vaadin.Router Redirect Examples",
+        "description": "",
+        "image": ""
+      }
+    },
+    {
+      "name": "Lazy Loading",
+      "url": "vaadin-router-lazy-loading-demos",
+      "src": "vaadin-router-lazy-loading-demos.html",
+      "meta": {
+        "title": "Vaadin.Router Lazy Loading Examples",
         "description": "",
         "image": ""
       }
@@ -42,21 +52,11 @@
       }
     },
     {
-      "name": "Redirect",
-      "url": "vaadin-router-redirect-demos",
-      "src": "vaadin-router-redirect-demos.html",
+      "name": "Navigation Triggers",
+      "url": "vaadin-router-navigation-trigger-demos",
+      "src": "vaadin-router-navigation-trigger-demos.html",
       "meta": {
-        "title": "Vaadin.Router Redirect Examples",
-        "description": "",
-        "image": ""
-      }
-    },
-    {
-      "name": "Lazy Loading",
-      "url": "vaadin-router-lazy-loading-demos",
-      "src": "vaadin-router-lazy-loading-demos.html",
-      "meta": {
-        "title": "Vaadin.Router Lazy Loading Examples",
+        "title": "Vaadin.Router Navigation Trigger Examples",
         "description": "",
         "image": ""
       }

--- a/demo/vaadin-router-basic-demos.html
+++ b/demo/vaadin-router-basic-demos.html
@@ -90,7 +90,7 @@
       <template preserve-content>
         <a href="/">Home</a>
         <a href="/users">All Users</a>
-        <a href="/users/kim">Kim</a>
+        <a href="/kim">Kim</a>
         <div id="outlet"></div>
         <script type="module">
           // import {Router} from '@vaadin/router';

--- a/demo/vaadin-router-basic-demos.html
+++ b/demo/vaadin-router-basic-demos.html
@@ -63,8 +63,8 @@
       routes config can be expressed as a flat list, or as a parent-childern
       tree. The routes config in the example below is effectively the same as in
       the example above.</p>
-    <p>The leading <code>'/'</code> in child route paths is optional &ndash;
-      they are always relative to the path of the parent route.</p>
+    <p>The leading <code>'/'</code> in child route paths is optional&mdash;they
+      are always relative to the path of the parent route.</p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>

--- a/demo/vaadin-router-basic-demos.html
+++ b/demo/vaadin-router-basic-demos.html
@@ -22,16 +22,21 @@
   var Router = Vaadin.Router;
 &lt;/script&gt;</code></pre>
 
-    <h3>Basic</h3>
-    <p>Vaadin.Router needs an outlet (a DOM Node to render into), and a routes
-      config. Once created, it automatically subscribes to <code>popstate</code> events on
-      the <code>window</code> and updates the rendered component every time
-      either the location or the routes config changes.</p>
-    <p>The routes config maps paths to Web Components. Vaadin.Router goes
+    <h3>Getting Started</h3>
+    <p>Vaadin.Router automatically listens to navigation events and
+      asynchronously renders a matching Web Component into the given DOM node
+      (a.k.a. the router <em>outlet</em>). By default, navigation events are
+      triggered by <code>popstate</code> events on the <code>window</code>, and
+      by <code>click</code> events on <code>&lt;a&gt;</code> elements on the
+      page (see <a href="vaadin-router-navigation-trigger-demos">Navigation
+      Triggers</a> for details).</p>
+    <p>The routes config maps URL paths to Web Components. Vaadin.Router goes
       through the routes until it finds the first match, creates an instance
       of the route component, and inserts it into the router outlet (replacing
-      any pre-existing outlet content).</p>
-    <p>The route component can be any Web Component regardless of how it is
+      any pre-existing outlet content). For details on the route path syntax
+      see the <a href="vaadin-router-route-parameters-demos">Router Parameters
+      </a> demos.</p>
+    <p>Route components can be any Web Components regardless of how they are
       built: vanilla JavaScript, Polymer, Stencil, SkateJS, Angular, Vue, etc</p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-1" iframe-src="iframe.html">
       <template preserve-content>
@@ -46,13 +51,20 @@
           router.setRoutes([
             {path: '/', component: 'x-home-view'},
             {path: '/users', component: 'x-user-list'},
+            {path: '/users/:user', component: 'x-user-profile'},
           ]);
         </script>
       </template>
     </vaadin-demo-snippet>
 
     <h3>Child Routes</h3>
-    <p>Each route can have child routes:</p>
+    <p>Each route can have child routes, which makes it easier to group related
+      routes together under a common parent. This is optional, i.e. the same
+      routes config can be expressed as a flat list, or as a parent-childern
+      tree. The routes config in the example below is effectively the same as in
+      the example above.</p>
+    <p>The leading <code>'/'</code> in child route paths is optional&mdash;they
+      are always relative to the path of the parent route.</p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>
@@ -77,15 +89,37 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Ambiguous Match</h3>
+    <h3>Ambiguous Matches</h3>
     <p>
-      URL matching rules can be ambiguous, so that several routes would match the same URL string.
-      In that case, the order in which the rules are defined, from top to bottom, determines the
-      matching route. The first matching route will be loaded.</p>
+      Route matching rules can be ambiguous, so that several routes would match
+      the same path. In that case, the order in which the routes are defined is
+      important. The first route matching the path gets rendered (starting from
+      the top of the list / root of the tree).</p>
     <p>
-      Always place any exactly matching route objects at the top of the list, and the wildcard
-      route, if any, should come after them. Otherwise, in the example below you would get the
-      <code>&lt;x-user-profile&gt;</code> component rendered for the <code>/users</code> URL.</p>
+      The default route matching is <strong>exact</strong>, i.e. a
+      <code>'/user'</code> route (if it does not have children) matches only the
+      <code>'/user'</code> path, but not <code>'/users'</code> nor
+      <code>'/user/42'</code>. Trailing slashes are not significant in paths,
+      but are significant in routes, i.e. a <code>'/user'</code> route matches
+      both <code>'/user'</code> the <code>'/user/'</code>, but a
+      <code>'/user/'</code> route matches only the <code>'/user/'</code> path.
+    </p>
+    <p><strong>Prefix</strong> matching is used for routes with children, or if
+      the route explicitly indicates that trailing content is expected (e.g.
+      a <code>'/users/(*.)'</code> route matches any path starting with
+      <code>'/users/'</code>).
+    </p>
+    <p>
+      Always place more specific routes before less specific:
+      <ul>
+        <li><code>{path: '/user/new', ...}</code> - matches only
+          <code>'/user/new'</code></li>
+        <li><code>{path: '/user/:user', ...}</code> - matches
+          <code>'/user/42'</code>, but not <code>'/user/42/edit'</code></li>
+        <li><code>{path: '/user/(.*)', ...}</code> - matches anything starting
+          with <code>'/user/'</code></li>
+      </ul>
+    </p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-3" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>
@@ -107,15 +141,15 @@
     </vaadin-demo-snippet>
 
     <h3>Fallback Routes (404)</h3>
-    <p>If Vaadin.Router does not find a matching route, it rejects the
-      <code>ready</code> promise and clears the router outlet. In order to show
-      a user-friendly 'page not found' view, a fallback route with a
-      <code>'(.*)'</code> path can be added to the <strong>end</strong> of the
-      routes list.</p>
+    <p>If Vaadin.Router does not find a matching route, the promise returned
+      from the <code>render()</code> method gets rejected, and any content in
+      the router outlet is removed. In order to show a user-friendly 'page not
+      found' view, a fallback route with a wildcard <code>'(.*)'</code> path can
+      be added to the <strong>end</strong> of the routes list.</p>
     <p>There can be different fallbacks for different route prefixes, but since
       the route resolution is based on the first match, the fallback route
       should always be <strong>after</strong> other alternatives.</p>
-    <p>The pathname that leads to the fallback route is available to the route
+    <p>The path that leads to the fallback route is available to the route
       component via the <code>route.pathname</code> property.</p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-4" iframe-src="iframe.html">
       <template preserve-content>

--- a/demo/vaadin-router-basic-demos.html
+++ b/demo/vaadin-router-basic-demos.html
@@ -28,13 +28,13 @@
       (a.k.a. the router <em>outlet</em>). By default, navigation events are
       triggered by <code>popstate</code> events on the <code>window</code>, and
       by <code>click</code> events on <code>&lt;a&gt;</code> elements on the
-      page (see <a href="vaadin-router-navigation-trigger-demos">Navigation
+      page (see <a href="#vaadin-router-navigation-trigger-demos">Navigation
       Triggers</a> for details).</p>
     <p>The routes config maps URL paths to Web Components. Vaadin.Router goes
       through the routes until it finds the first match, creates an instance
       of the route component, and inserts it into the router outlet (replacing
       any pre-existing outlet content). For details on the route path syntax
-      see the <a href="vaadin-router-route-parameters-demos">Router Parameters
+      see the <a href="#vaadin-router-route-parameters-demos">Router Parameters
       </a> demos.</p>
     <p>Route components can be any Web Components regardless of how they are
       built: vanilla JavaScript, Polymer, Stencil, SkateJS, Angular, Vue, etc</p>
@@ -63,8 +63,8 @@
       routes config can be expressed as a flat list, or as a parent-childern
       tree. The routes config in the example below is effectively the same as in
       the example above.</p>
-    <p>The leading <code>'/'</code> in child route paths is optional&mdash;they
-      are always relative to the path of the parent route.</p>
+    <p>The leading <code>'/'</code> in child route paths is optional &ndash;
+      they are always relative to the path of the parent route.</p>
     <vaadin-demo-snippet id="vaadin-router-basic-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>

--- a/demo/vaadin-router-lazy-loading-demos.html
+++ b/demo/vaadin-router-lazy-loading-demos.html
@@ -6,11 +6,25 @@
       }
     </style>
 
-    <h3>Lazy Loading</h3>
-    <p>Vaadin.Router supports loading <code>.js</code> and <code>.mjs</code> bundles asynchronously before rendering the route target.</p>
-    <p>Note: If any other type of bundle is specified, it won't be loaded but an exception will be thrown.
-      Refer to the next demo if you need to load different types of the bundles.</p>
-    <p>Current example loads <code>component-definition.js</code> script which creates and registers the component that serves as a route target.</p>
+    <h3>Lazy Loading JS Bundles</h3>
+    <p>
+      Vaadin.Router has a special support for lazy loading <code>.js</code> and
+      <code>.mjs</code> scripts just-in-time before rendering a route Web
+      Component. In order to use this feature, specify the script URL in a
+      <code>bundle</code> property of the route object.
+    </p>
+    <p>
+      Note: If the bundle URL does not end with <code>.js</code> nor with <code>
+      .mjs</code>, Vaadin.Router throws an <code>Error</code> and does not
+      attempt to loaded the bundle. Use a custom route action as shown in the
+      next demo if you need to load different types of the bundles.
+    </p>
+    <p>
+      This demo shows how to load the <code>component-definition.js</code>
+      script which defines the custom element for the <code>/lasy</code> route.
+      Check the network tab in the browser DevTools to see that the script is
+      loaded only after clickig at the <code>/lazy</code> route link.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-lazy-loading-1" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>
@@ -26,19 +40,27 @@
             {
               path: '/lazy',
               bundle: './demo-elements/component-definition.js',
-              component: 'x-bundle-test-view'
+              component: 'x-bundle-test-view' // <-- defined in the bundle
             },
           ]);
         </script>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Lazy Loading other types of bundles.</h3>
-    <p>Sometimes loading <code>.js</code> and <code>.mjs</code> is not enough.</p>
-    <p>Vaadin.Router allows executing arbitrary tasks via <code>action</code> route property,
-      which can be used for asynchronous bundle loading also.</p>
-    <p>Current example shows how it's possible to load <code>component-definition.html</code> bundle using Polymer 2 library</p>
-    <p><code>component-definition.html</code> contains the whole component definition: template and the script that registers it.</p>
+    <h3>Lazy Loading non-JS Bundles</h3>
+    <p>
+      In cases when loading <code>.js</code> and <code>.mjs</code> is not enough
+      &mdash;most notably, when using HTML imports in Polymer-based apps&mdash;
+      the lazy loading feature can be implemented with a custom route action
+      (for more details see <a href="vaadin-router-route-actions-demos">Route
+      Actions</a>).
+    </p>
+    <p>
+      This demo shows a way to lazily add an HTML import. The <code>
+      component-definition.html</code> file contains entire Polymer 2 component
+      definition including a template, a class, and a script that defines a
+      custom element.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-lazy-loading-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>
@@ -50,7 +72,8 @@
 
           const loadCustomBundle = () => {
             return new Promise((resolve, reject) => {
-              // This is just an example way of loading the bundle, you can use any other way you like to do so.
+              // This is one way of loading a bundle lazily (works for Polymer apps).
+              // Other apps might use different ways.
               Polymer.importHref(
                 './demo-elements/component-definition.html', () => resolve(), reject, true);
             });

--- a/demo/vaadin-router-lazy-loading-demos.html
+++ b/demo/vaadin-router-lazy-loading-demos.html
@@ -21,7 +21,7 @@
     </p>
     <p>
       This demo shows how to load the <code>component-definition.js</code>
-      script which defines the custom element for the <code>/lasy</code> route.
+      script which defines the custom element for the <code>/lazy</code> route.
       Check the network tab in the browser DevTools to see that the script is
       loaded only after clickig at the <code>/lazy</code> route link.
     </p>
@@ -49,11 +49,11 @@
 
     <h3>Lazy Loading non-JS Bundles</h3>
     <p>
-      In cases when loading <code>.js</code> and <code>.mjs</code> is not enough
-      &mdash;most notably, when using HTML imports in Polymer-based apps&mdash;
-      the lazy loading feature can be implemented with a custom route action
-      (for more details see <a href="vaadin-router-route-actions-demos">Route
-      Actions</a>).
+      In cases when loading <code>.js</code> and <code>.mjs</code> is not
+      enough&mdash;most notably, when using HTML imports in Polymer-based
+      apps&mdash;the lazy loading feature can be implemented with a custom route
+      action (for more details see <a href="#vaadin-router-route-actions-demos">
+      Route Actions</a>).
     </p>
     <p>
       This demo shows a way to lazily add an HTML import. The <code>

--- a/demo/vaadin-router-navigation-trigger-demos.html
+++ b/demo/vaadin-router-navigation-trigger-demos.html
@@ -148,7 +148,7 @@
     <h3>Unsubscribe from Navigation Events</h3>
     <p>
       Each Vaadin.Router instance is automatically subscribed to navigation
-      events upon creation. Sometimes it might be necessary to cacnel this
+      events upon creation. Sometimes it might be necessary to cancel this
       subscription so that the router would re-render only in response to the
       explicit <code>render()</code> method calls. Use the <code>unsubscribe()
       </code> method to cancel this automatic subscription and the <code>

--- a/demo/vaadin-router-navigation-trigger-demos.html
+++ b/demo/vaadin-router-navigation-trigger-demos.html
@@ -46,7 +46,7 @@
       <code>window.history.replaceState()</code> methods, you need to dispatch
       the <code>popstate</code> event manually&mdash;these methods do not do
       that by themselves (see <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API"
-      target="_blank">MDN</a> for details).
+      target="_blank" rel="noopener">MDN</a> for details).
     </p>
     <vaadin-demo-snippet id="vaadin-router-navigation-trigger-demo-1" iframe-src="iframe.html">
       <template preserve-content>
@@ -148,8 +148,8 @@
     <h3>Unsubscribe from Navigation Events</h3>
     <p>
       Each Vaadin.Router instance is automatically subscribed to navigation
-      events upon creation. Sometimes it might be necessary to canel this
-      subscription so that the router would re-render only in response to
+      events upon creation. Sometimes it might be necessary to cacnel this
+      subscription so that the router would re-render only in response to the
       explicit <code>render()</code> method calls. Use the <code>unsubscribe()
       </code> method to cancel this automatic subscription and the <code>
       subscribe()</code> method to re-subscribe.

--- a/demo/vaadin-router-navigation-trigger-demos.html
+++ b/demo/vaadin-router-navigation-trigger-demos.html
@@ -6,37 +6,48 @@
       }
     </style>
 
-    <h3>Navigation Trigger Concept</h3>
+    <h3>Navigation Triggers</h3>
     <p>
-      There are several events that can trigger in-app navigation with <code>Vaadin.Router</code>:
-      popstate events, clicks on the <code>&lt;a&gt;</code> elements, imperative navigation triggered by JavaScript.
-      In order to make a flexible solution that can be tweaked to particular app needs and remain efficient,
-      <code>Vaadin.Router</code> has a concept of pluggable Navigation Triggers that listen to specific
-      browser events and convert them into the <code>Vaadin.Router</code> navigation events.</p>
+      There are several events that can trigger in-app navigation with
+      Vaadin.Router: popstate events, clicks on the <code>&lt;a&gt;</code>
+      elements, imperative navigation triggered by JavaScript. In order to make
+      a flexible solution that can be tweaked to particular app needs and remain
+      efficient, Vaadin.Router has a concept of pluggable <em>Navigation
+      Triggers</em> that listen to specific browser events and convert them into
+      the Vaadin.Router navigation events.
+    </p>
     <p>
-      The <code>@vaadin/router</code> package comes with two Navigation Triggers bundled by default:
-      <code>POPSTATE</code> and <code>CLICK</code>.</p>
-    <p>According to the naming convention, the Navigation Trigger object must implement two methods:
-      <code>activate</code> to start listening on some UI events, and <code>deactivate</code> to stop.
-      You should use them to add and remove the event listeners you need, respectively.</p>
+      The <code>@vaadin/router</code> package comes with two Navigation
+      Triggers bundled by default: <code>POPSTATE</code> and <code>CLICK</code>.
+    </p>
+    <p>
+      Developers can define and use additional Navigation Triggers that are
+      specific to their application. A Navigation Trigger object must have
+      two methods: <code>activate()</code> to start listening on some UI events,
+      and <code>deactivate()</code> to stop.
+    </p>
 
-    <h3>NavigationTrigger.POPSTATE</h3>
+    <h3><code>NavigationTrigger.POPSTATE</code></h3>
     <p>
-      The default <code>POPSTATE</code> navigation trigger for <code>Vaadin.Router</code> intercepts
-      <code>popstate</code> events on the current <code>window</code> and for
-      each of them dispatches a navigation event for <code>Vaadin.Router</code>
+      The default <code>POPSTATE</code> navigation trigger for Vaadin.Router
+      listens to <code>popstate</code> events on the current <code>window</code>
+      and for each of them dispatches a navigation event for Vaadin.Router
       using the current <code>window.location.pathname</code> as the navigation
-      target.
+      target. This allows using the browser Forward and Back buttons for in-app
+      navigation.
     </p>
     <p>
       In the demo below the <code>popstate</code> events are dispatched at 3
       seconds intervals. Before dispatching an event the global <code>
-      location.pathname</code> is toggled between '/' and '/users'.</p>
+      location.pathname</code> is toggled between '/' and '/users'.
+    </p>
     <p>
-      Please note that you must dispatch the <code>popstate</code> event manually after
-      you invoke either <code>window.history.pushState</code> or <code>window.history.replaceState</code>.
-      Those methods do not do that by themselves and only alter the <code>history</code> object.
-      This is an "undo" feature for single page applications.</p>
+      Please note that when using the <code>window.history.pushState()</code> or
+      <code>window.history.replaceState()</code> methods, you need to dispatch
+      the <code>popstate</code> event manually&mdash;these methods do not do
+      that by themselves (see <a href="https://developer.mozilla.org/en-US/docs/Web/API/History_API"
+      target="_blank">MDN</a> for details).
+    </p>
     <vaadin-demo-snippet id="vaadin-router-navigation-trigger-demo-1" iframe-src="iframe.html">
       <template preserve-content>
         <div id="outlet"></div>
@@ -59,13 +70,14 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>NavigationTrigger.CLICK</h3>
+    <h3><code>NavigationTrigger.CLICK</code></h3>
     <p>
       The <code>CLICK</code> navigation trigger intercepts clicks on
       <code>&lt;a&gt;</code> elements on the the page and converts them into
-      navigation events for <code>Vaadin.Router</code> if they refer to a
+      navigation events for Vaadin.Router if they refer to a
       location within the app. That allows using regular <code>&lt;a&gt;</code>
-      link elements for in-app navigation.</p>
+      link elements for in-app navigation.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-navigation-trigger-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>
@@ -84,14 +96,25 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Switch Navigation Triggers</h3>
+    <h3>Custom Navigation Triggers</h3>
     <p>
-      The set of default navigation triggers can be changed using
-      the <code>Router.setTriggers()</code> static method. It accepts zero,
-      one or more <code>NavigationTrigger</code>s.</p>
-    <p>The demo below demonstrates how you can disable a <code>CLICK</code> navigation trigger
-      and setup a custom event listener used to fire <code>popstate</code> event on list item click.
-      Use this approach, if you want to implement custom in-app navigation links.</p>
+      The set of default navigation triggers can be changed using the <code>
+      Router.setTriggers()</code> static method. It accepts zero, one or more
+      <code>NavigationTrigger</code>s.
+    </p>
+    <p>
+      This demo shows how to disable the <code>CLICK</code> navigation trigger.
+      It may be useful when the app has an own custom element for in-app links
+      instead of using the regular <code>&lt;a&gt;</code> elements for that
+      purpose. The demo also shows a very basic version of a custom in-app link
+      element based on a list element that fires <code>popstate</code> events
+      when clicked.
+    </p>
+    <p>
+      Note: if the default Navigation Triggers are not used by the app, they can
+      be excluded from the app bundle to avoid sending unnecessary code to the
+      users. See <code>src/router-config.js</code> for details.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-navigation-trigger-demo-3" iframe-src="iframe.html">
       <template preserve-content>
         <ul>
@@ -102,7 +125,6 @@
         <script type="module">
           // import {Router} from '@vaadin/router';
           const {Router} = window.Vaadin;
-
           const {POPSTATE} = Router.NavigationTrigger;
           Router.setTriggers(POPSTATE);
 
@@ -123,11 +145,15 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Unsubscribe from Automatic Navigation Triggers</h3>
-    <p>Each <code>Vaadin.Router</code> instance is automatically subscribed
-      to navigation events in its constructor. Use the
-      <code>unsubscribe()</code> method to cancel this automatic subscription
-      and the <code>subscribe()</code> method to re-subscribe.</p>
+    <h3>Unsubscribe from Navigation Events</h3>
+    <p>
+      Each Vaadin.Router instance is automatically subscribed to navigation
+      events upon creation. Sometimes it might be necessary to canel this
+      subscription so that the router would re-render only in response to
+      explicit <code>render()</code> method calls. Use the <code>unsubscribe()
+      </code> method to cancel this automatic subscription and the <code>
+      subscribe()</code> method to re-subscribe.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-navigation-trigger-demo-4" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>

--- a/demo/vaadin-router-redirect-demos.html
+++ b/demo/vaadin-router-redirect-demos.html
@@ -6,16 +6,28 @@
       }
     </style>
 
-    <h3>Unconditional Redirect</h3>
-    <p>Vaadin.Router supports the <code>redirect</code> property on the route object,
-      allowing to unconditionally redirect users from one URL to another.
-      The valid values are path string or pattern in the same format, as used for the
-      <code>path</code> property.</p>
-    <p>The redirected URL is not stored as the <code>window.history</code> entry
-      and cannot be reached by pressing "Back" browser button.
-      Unconditional redirects work for routes both with and without parameters.</p>
-    <p>When defined, this property overrides other route properties: both <code>action</code>
-      and <code>component</code> properties will be ignored.</p>
+    <h3>Unconditional Redirects</h3>
+    <p>
+      Vaadin.Router supports the <code>redirect</code> property on the route
+      objects, allowing to unconditionally redirect users from one path to
+      another. The valid values are a path string or a pattern in the same
+      format as used for the <code>path</code> property.
+    </p>
+    <p>
+      The original path is not stored as the <code>window.history</code> entry
+      and cannot be reached by pressing the "Back" browser button. Unconditional
+      redirects work for routes both with and without parameters. The original
+      path is available to the route component as the <code>route.redirect.from
+      </code> string property, and to custom route actions as <code>context.from
+      </code>.
+    </p>
+    <p>
+      Note: If a route has both the <code>redirect</code> and <code>action</code>
+      properties, <code>action</code> is executed first and if it does not
+      return a result Vaadin.Router proceeds to check the <code>redirect</code>
+      property. Other route properties (if any) would be ignored. In that case
+      Vaadin.Router would also log a warning to the browser console.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-redirect-demos-1" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>

--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -6,15 +6,42 @@
       }
     </style>
 
-    <h3>Custom Route Action</h3>
-    <p>Vaadin.Router provides an API for handling the current route:
-    <ul>
-      <li><code>context.pathname</code> property holding the current path string</li>
-      <li><code>context.next</code> method for navigating to the next route in the route's list (if any)</li>
-      <li><code>context.params</code> object that holds current route's parameters</li>
-    </ul>
+    <h3>Custom Route Actions</h3>
+    <p>
+      Route resolution is an async operation started by a navigation event, or
+      by an explicit <code>render()</code> method call. In that process
+      Vaadin.Router goes through the routes config and tries to <em>resolve</em>
+      each matching route from the root onwards. The default route resolution
+      rule is to create and return an instance of the route's <code>component
+      </code> (see the API docs for the <code>setRoutes()</code> method for
+      details on other route properties and how they affect the route resolution).
     </p>
-    <p>Current example demonstrates the way to get visit statistics for each dedicated URL.</p>
+    <p>
+      Vaadin.Router provides a flexible API to customize the default route
+      resolution rule. Each route may have an <code>action</code> functional
+      property that defines how exactly that route is resolved. An <code>action
+      </code> function may or may not return a value. If it does, that completed
+      the resolution pass, and the returned value is what gets rendered. If it
+      returns <code>null</code> or <code>undefined</code>, the resolution
+      process continues to check the other properties of the route and apply the
+      default resolution rules, and further, to check other matching routes if
+      necessary.
+    </p>
+    <p>
+      The <code>action(context)</code> function reveives a <code>context</code>
+      parameter with the following properties:
+      <ul>
+        <li><code>context.pathname</code> [string] the pathname being resolved
+          </li>
+        <li><code>context.params</code> [object] the route parameters</li>
+        <li><code>context.next</code> [function] proceed to resolving the next
+          matching route (if any)</li>
+      </ul>
+    </p>
+    <p>
+      This demo shows how to use the custom <code>action</code> property to
+      collect visit statistics for each route.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-route-actions-demo-1" iframe-src="iframe.html">
       <template preserve-content>
         <nav>
@@ -35,7 +62,7 @@
             urlToNumberOfVisits[visitedPath] = (urlToNumberOfVisits[visitedPath] || 0) + 1;
             document.getElementById('stats').innerHTML =
               `Statistics on URL visits: ${JSON.stringify(urlToNumberOfVisits, null, 2)}}`;
-            return context.next(); // redirect to the next route in the list
+            return context.next(); // pass to the next route in the list
           };
 
           const router = new Router(document.getElementById('outlet'));
@@ -55,11 +82,22 @@
     </vaadin-demo-snippet>
 
     <h3>Async Route Resolution</h3>
-    <p>Each route can have <code>action</code> method which is called before navigation to the path specified.</p>
-    <p>This method can be used for complex navigation cases. If you need to simply open the page specified, use
-      <code>component</code> instead.</p>
-    <p>Note: For a single route, both <code>component</code> and <code>action</code> cannot be defined.</p>
-    <p>Current example demonstrates the way you can perform async tasks on view enter</p>
+    <p>
+      Since route resolution is async, the <code>action()</code> callback may be
+      async as well and return a promise. One use case for that is to create
+      a custom route action that makes a remote API call to fetch the data
+      necessary to render the route component, before navigating to a route.
+    </p>
+    <p>
+      Note: If a route has both the <code>component</code> and <code>action
+      </code> properties, <code>action</code> is executed first and if it does
+      not return a result Vaadin.Router proceeds to check the <code>component
+      </code> property.
+    </p>
+    <p>
+      This demo shows a way to perform async tasks before navigating to any
+      route under <code>/users</code>.
+    </p>
     <vaadin-demo-snippet id="vaadin-router-route-actions-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <nav>

--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -20,15 +20,14 @@
       Vaadin.Router provides a flexible API to customize the default route
       resolution rule. Each route may have an <code>action</code> functional
       property that defines how exactly that route is resolved. An <code>action
-      </code> function may or may not return a value. If it does, that completed
-      the resolution pass, and the returned value is what gets rendered. If it
-      returns <code>null</code> or <code>undefined</code>, the resolution
-      process continues to check the other properties of the route and apply the
-      default resolution rules, and further, to check other matching routes if
-      necessary.
+      </code> function may or may not return a value. If it does, that completes
+      the resolution pass, and the returned value is what gets rendered.
+      Otherwise, the resolution process continues to check the other properties
+      of the route and apply the default resolution rules, and then further to
+      check other matching routes.
     </p>
     <p>
-      The <code>action(context)</code> function reveives a <code>context</code>
+      The <code>action(context)</code> function receives a <code>context</code>
       parameter with the following properties:
       <ul>
         <li><code>context.pathname</code> [string] the pathname being resolved
@@ -36,6 +35,19 @@
         <li><code>context.params</code> [object] the route parameters</li>
         <li><code>context.next</code> [function] proceed to resolving the next
           matching route (if any)</li>
+      </ul>
+      The supported return values are
+      <ul>
+        <li>an instance of <code>HTMLElement</code></li>
+        <li>a <em>redirect</em> object, i.e. an <code>object</code> with a
+          <code>redirect</code> property that looks like <code><pre>{
+  redirect: {
+    pathname: '/new/path/:param',
+    from: '/old/path/:param',
+    params: /* the parameters object (if any) */
+  }
+}</pre></code></li>
+        <li><code>null</code> or <code>undefined</code></li>
       </ul>
     </p>
     <p>

--- a/demo/vaadin-router-route-parameters-demos.html
+++ b/demo/vaadin-router-route-parameters-demos.html
@@ -8,15 +8,16 @@
 
     <h3>Route Parameters</h3>
     <p>Route parameters are useful when the same Web Component should be
-      rendered for a set paths, where a part of the path is static, and another
-      part contains a parameter value. E.g. for both <code>/user/1</code> and
-      <code>/user/42</code> paths it's the same Web Component that renders the
-      content, the <code>/user/</code> part is static, and <code>1</code> and
-      <code>42</code> are the parameter values.</p>
+      rendered for a number of paths, where a part of the path is static, and
+      another part contains a parameter value. E.g. for both <code>/user/1
+      </code> and <code>/user/42</code> paths it's the same Web Component that
+      renders the content, the <code>/user/</code> part is static, and <code>1
+      </code> and <code>42</code> are the parameter values.</p>
     <p>Route parameters are defined using an express.js-like syntax. The
       implementation is based on the <a href="https://github.com/pillarjs/path-to-regexp#parameters"
-      target="_blank">path-ot-regexp</a> library that is also used in several
-      popular front-end frameworks. All features are supported:
+      target="_blank" rel="noopener">path-ot-regexp</a> library that is commonly
+      used in modern front-end libraries and frameworks. All features are
+      supported:
       <ul>
         <li>named parameters: <code>/profile/:user</code></li>
         <li>optional parameters: <code>/:size/:color?</code></li>

--- a/demo/vaadin-router-route-parameters-demos.html
+++ b/demo/vaadin-router-route-parameters-demos.html
@@ -7,8 +7,16 @@
     </style>
 
     <h3>Route Parameters</h3>
-    <p>Route parameters are defined using the <a href="https://github.com/pillarjs/path-to-regexp#parameters"
-      target="_blank">express-like syntax</a>. All features are supported:
+    <p>Route parameters are useful when the same Web Component should be
+      rendered for a set paths, where a part of the path is static, and another
+      part contains a parameter value. E.g. for both <code>/user/1</code> and
+      <code>/user/42</code> paths it's the same Web Component that renders the
+      content, the <code>/user/</code> part is static, and <code>1</code> and
+      <code>42</code> are the parameter values.</p>
+    <p>Route parameters are defined using an express.js-like syntax. The
+      implementation is based on the <a href="https://github.com/pillarjs/path-to-regexp#parameters"
+      target="_blank">path-ot-regexp</a> library that is also used in several
+      popular front-end frameworks. All features are supported:
       <ul>
         <li>named parameters: <code>/profile/:user</code></li>
         <li>optional parameters: <code>/:size/:color?</code></li>
@@ -45,12 +53,17 @@
     </vaadin-demo-snippet>
 
     <h3>Accessing Route Parameters</h3>
-    <p>Named parameters are bound to the <code>route.params</code> property of the route component
-      (the <code>route</code> property is set on the route component by the router).</p>
+    <p>Route parameters are bound to the <code>route.params</code> property of
+      the route Web Component (the <code>route</code> property is set on the
+      route component by Vaadin.Router).</p>
     <ul>
-      <li>Named parameters are accessible by string key.</li>
-      <li>Unnamed parameters are accessible by numeric index.</li>
+      <li>Named parameters are accessible by a string key, e.g.
+        <code>route.params.id</code> or <code>route.params['id']</code></li>
+      <li>Unnamed parameters are accessible by a numeric index, e.g.
+        <code>route.params[0]</code></li>
     </ul>
+    <p>The example below shows how to access route parameters in a Polymer 2
+      based Web Component:</p>
     <vaadin-demo-snippet id="vaadin-router-route-parameters-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>


### PR DESCRIPTION
 - rewrite the demo descriptions to make them use more consistent terminology
 - rename "Basic" to "Getting Started"
 - reorder the demos so that navigation triggers and custom actions are in the end, after more basic concepts as redirects and lazy loading

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/115)
<!-- Reviewable:end -->
