### PR TITLE
Fill context with the information on which route triggered the function.

### DIFF
--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -33,12 +33,14 @@
         <li><code>context.pathname</code> [string] the pathname being resolved
           </li>
         <li><code>context.params</code> [object] the route parameters</li>
-        <li><code>context.next</code> [function] proceed to resolving the next
-          matching route (if any)</li>
+        <li><code>context.route</code> [object] the route that is currently being rendered</li>
+        <li><code>context.next()</code> [function] function for asynchronously getting the next route contents from the resolution chain (if any)</li>
         <li><code>context.redirect(path)</code> [function] that creates a redirect data for the path specified.
         This data can be returned from <code>action</code> to perform an actual redirect</li>
         <li><code>context.component(component)</code> [function] that creates a new <code>HTMLElement</code>
           with current context</li>
+        <li><code>context.cancel()</code> [function] that creates an object that can be returned from `inactivate` function.
+          If an `action` returns `context.cancel()`, it will be considered as no return value.</li>
       </ul>
       The supported return values are
       <ul>

--- a/src/router.js
+++ b/src/router.js
@@ -37,16 +37,9 @@ function renderComponent(context, component) {
 }
 
 function runCallbackIfPossible(callback, context, invocationPath) {
-  if (callback && typeof callback === 'function') {
-    const result = callback(Object.assign({}, context, {invocationPath: invocationPath}));
-    if (!redirectsToCurrentStateSecondTimeInARow(context, (result || {}).redirect)) {
-      return result;
-    }
+  if (typeof callback === 'function') {
+    return callback(Object.assign({}, context, {invocationPath: invocationPath}));
   }
-}
-
-function redirectsToCurrentStateSecondTimeInARow(context, redirectData) {
-  return redirectData && context.pathname === redirectData.pathname && context.from === redirectData.from;
 }
 
 /**
@@ -130,10 +123,7 @@ export class Router extends Resolver {
     }
 
     if (typeof route.redirect === 'string') {
-      const redirectTarget = context.redirect(route.redirect);
-      if (!redirectsToCurrentStateSecondTimeInARow(context, redirectTarget.redirect)) {
-        return redirectTarget;
-      }
+      return context.redirect(route.redirect);
     }
 
     if (route.path) {

--- a/src/router.js
+++ b/src/router.js
@@ -115,7 +115,7 @@ export class Router extends Resolver {
     context.component = function(component) {
       return renderComponent(this, component);
     };
-      context.cancel = () => ({cancel: true});
+    context.cancel = () => ({cancel: true});
 
     const actionResult = runCallbackIfPossible(processAction, context, route);
     if (isResultNotEmpty(actionResult) && !actionResult.cancel) {

--- a/src/router.js
+++ b/src/router.js
@@ -38,7 +38,7 @@ function renderComponent(context, component) {
 
 function runCallbackIfPossible(callback, context, invocationPath) {
   if (typeof callback === 'function') {
-    return callback(Object.assign({}, context, {invocationPath: invocationPath}));
+    return callback(Object.assign({}, context, {invocationPath}));
   }
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -241,22 +241,27 @@ export class Router extends Resolver {
    * If `inactivate` method returns `context.cancel()`, inactivation and new path resolution is cancelled and
    * router restores the state before the new resolution.
    * Otherwise router updates the active routes and waits for the next resolution to happen.
+   * NOTE: `inactivate` is considered to be an internal router feature, for the examples, refer to the router tests.
    *
-   * `context` objet that is passed to `route` functions holds the following parameters:
-   *  * `context.next()` for asynchronously getting the next route contents from the resolution chain (if any)
+   * `context` object that is passed to `route` functions holds the following parameters:
+   * * `context.pathname` – string with the pathname being resolved
    *
-   *  * `context.params` with route parameters
+   * * `context.params` – object with route parameters
    *
-   *  * `route` that holds the route that is currently being rendered.
+   * * `context.route` – object that holds the route that is currently being rendered.
    * If the function defined not as an arrow one but with the `function` keyword, its `this` property points to the route that had
    * defined the function.
    * This is important in `inactivate` case, where `this !== context.route`, since currently resolved route
    * is not the one that is being inactivated. For `action` is is true that `this === context.route`.
    *
-   * * `context.cancel()` that creates an object that can be returned from `inactivate` function.
-   * If an `action` returns `context.cancel()`, it will be considered as no return value.
+   * * `context.next()` – function for asynchronously getting the next route contents from the resolution chain (if any)
    *
-   * NOTE: `inactivate` is considered to be an internal router feature, for the examples, refer to the router tests.
+   * * `context.redirect(path)` – function that creates a redirect data for the path specified.
+   *
+   * * `context.component(component)` – function that creates a new HTMLElement with current context
+   *
+   * * `context.cancel()` – function that creates an object that can be returned from `inactivate` function.
+   * If an `action` returns `context.cancel()`, it will be considered as no return value.
    *
    * @param {!Array<!Object>|!Object} routes a single route or an array of those
    */

--- a/src/router.js
+++ b/src/router.js
@@ -249,10 +249,12 @@ export class Router extends Resolver {
    * * `context.params` – object with route parameters
    *
    * * `context.route` – object that holds the route that is currently being rendered.
-   * If the function defined not as an arrow one but with the `function` keyword, its `this` property points to the route that had
-   * defined the function.
-   * This is important in `inactivate` case, where `this !== context.route`, since currently resolved route
-   * is not the one that is being inactivated. For `action` is is true that `this === context.route`.
+   * The original `route` object that defined an `action` or `inactivate` callback is available inside the callback
+   * through the `this` reference. The current route object being currently resolved is available there as `context.route`.
+   * While for `action` callbacks these are always the same, for `inactivate` callbacks these objects would be different:
+   * the current route that is being rendered causes another route to inactivate.
+   * If you need to access the original route object, make sure you define the `inactivate` callback as a non-arrow
+   * function because arrow functions do not have their own `this` reference.
    *
    * * `context.next()` – function for asynchronously getting the next route contents from the resolution chain (if any)
    *

--- a/src/router.js
+++ b/src/router.js
@@ -9,15 +9,15 @@ function isResultNotEmpty(result) {
 
 function redirect(context, path) {
   const params = Object.assign({}, context.params);
-  return {redirect: {pathname: path, from: getInvocationPath(context), params}};
+  return {redirect: {pathname: path, from: getInvocationPathName(context), params}};
 }
 
-function getInvocationPath(context) {
-  if (!context.invocationPath) {
+function getInvocationPathName(context) {
+  if (!context.invocationRoute) {
     return context.pathname;
   }
 
-  let currentPath = context.invocationPath;
+  let currentPath = context.invocationRoute;
   let invocationPathName = '';
   while (currentPath) {
     invocationPathName = currentPath.path + invocationPathName;
@@ -36,9 +36,9 @@ function renderComponent(context, component) {
   return element;
 }
 
-function runCallbackIfPossible(callback, context, invocationPath) {
+function runCallbackIfPossible(callback, context, invocationRoute) {
   if (typeof callback === 'function') {
-    return callback(Object.assign({}, context, {invocationPath}));
+    return callback(Object.assign({}, context, {invocationRoute}));
   }
 }
 
@@ -246,10 +246,10 @@ export class Router extends Resolver {
    *  * `context.next()` for asynchronously getting the next route contents from the resolution chain (if any)
    *  * `context.params` with route parameters
    *  * `route` that holds the route that is currently being rendered
-   *  * `invocationPath` that holds the route that is causing the current function to be executed
-   * For `action`, `context.invocationPath === context.route`, since `action` is immediately executed when the route is being rendered.
-   * For `inactivate`, `context.invocationPath !== context.route`: current route that is being rendered causes the other route
-   * inactivation and the inactivated route would be the one that is contained in `context.invocationPath`
+   *  * `invocationRoute` that holds the route that is causing the current function to be executed
+   * For `action`, `context.invocationRoute === context.route`, since `action` is immediately executed when the route is being rendered.
+   * For `inactivate`, `context.invocationRoute !== context.route`: current route that is being rendered causes the other route
+   * inactivation and the inactivated route would be the one that is contained in `context.invocationRoute`
    * * `context.cancel()` that creates an object that can be returned from `inactivate` function.
    * If an `action` returns `context.cancel()`, it will be considered as no return value.
    *

--- a/src/router.js
+++ b/src/router.js
@@ -244,18 +244,15 @@ export class Router extends Resolver {
    *
    * `context` objet that is passed to `route` functions holds the following parameters:
    *  * `context.next()` for asynchronously getting the next route contents from the resolution chain (if any)
-   *  * `context.params` with route parameters
-   *  * `route` that holds the route that is currently being rendered.
    *
+   *  * `context.params` with route parameters
+   *
+   *  * `route` that holds the route that is currently being rendered.
    * If the function defined not as an arrow one but with the `function` keyword, its `this` property points to the route that had
    * defined the function.
    * This is important in `inactivate` case, where `this !== context.route`, since currently resolved route
    * is not the one that is being inactivated. For `action` is is true that `this === context.route`.
    *
-   *  * `invocationRoute` that holds the route that is causing the current function to be executed
-   * For `action`, `context.invocationRoute === context.route`, since `action` is immediately executed when the route is being rendered.
-   * For `inactivate`, `context.invocationRoute !== context.route`: current route that is being rendered causes the other route
-   * inactivation and the inactivated route would be the one that is contained in `context.invocationRoute`
    * * `context.cancel()` that creates an object that can be returned from `inactivate` function.
    * If an `action` returns `context.cancel()`, it will be considered as no return value.
    *

--- a/src/router.js
+++ b/src/router.js
@@ -209,13 +209,9 @@ export class Router extends Resolver {
    * [express.js syntax](https://expressjs.com/en/guide/routing.html#route-paths").
    *
    * * `action` – the action that is executed before the route is resolved.
-   * The value for this property should be a function, accepting a `context` parameter.
+   * The value for this property should be a function, accepting a `context` parameter described below.
    * If present, this function is always invoked first, disregarding of the other properties' presence.
    * If the action returns a non-empty result, current route resolution is finished and other route config properties are ignored.
-   * `context` parameter can be used for asynchronously getting the resolved route contents via `context.next()`
-   * and for getting route parameters via `context.params`. `context.cancel()` creates an object that can be returned
-   * during `inactivate` method execution (described below) to abort ongoing route resolution. If an `action` return
-   * `context.cancel()`, it will be considered as no return value.
    * See also **Route Actions** section in [Live Examples](#/classes/Vaadin.Router/demos/demo/index.html).
    *
    * * `redirect` – other route's path to redirect to. Passes all route parameters to the redirect target.
@@ -228,7 +224,7 @@ export class Router extends Resolver {
    * See also **Lazy Loading** section in [Live Examples](#/classes/Vaadin.Router/demos/demo/index.html).
    *
    * * `component` – the tag name of the Web Component to resolve the route to.
-   *The property is ignored when either an `action` returns the result or `redirect` property is present.
+   * The property is ignored when either an `action` returns the result or `redirect` property is present.
    *
    * * `children` – nested routes. Parent routes' properties are executed before resolving the children.
    * Children 'path' values are relative to the parent ones.
@@ -241,12 +237,21 @@ export class Router extends Resolver {
    * if, for previous example, user visits '/a/d' path and it's a valid path, routes '/c' and '/b' will be inactivated.
    * Inactivation always happens from the last active element to the first that is different from the new route,
    * if the method is not defined for any route, the route is skipped.
-   * Each `inactivate` call gets a `context` parameter, described above.
-   * In this case, context parameter contains an additional `inactivatedRoute` property,
-   * that holds an information on the currently inactivated route.
-   * If `inactivate` method returns `context.cancel()`, inactivation and new path resolution is cancelled,
-   * router restores the state before new resolution.
+   * Each `inactivate` call gets a `context` parameter, described below.
+   * If `inactivate` method returns `context.cancel()`, inactivation and new path resolution is cancelled and
+   * router restores the state before the new resolution.
    * Otherwise router updates the active routes and waits for the next resolution to happen.
+   *
+   * `context` objet that is passed to `route` functions holds the following parameters:
+   *  * `context.next()` for asynchronously getting the next route contents from the resolution chain (if any)
+   *  * `context.params` with route parameters
+   *  * `route` that holds the route that is currently being rendered
+   *  * `invocationPath` that holds the route that is causing the current function to be executed
+   * For `action`, `context.invocationPath === context.route`, since `action` is immediately executed when the route is being rendered.
+   * For `inactivate`, `context.invocationPath !== context.route`: current route that is being rendered causes the other route
+   * inactivation and the inactivated route would be the one that is contained in `context.invocationPath`
+   * * `context.cancel()` that creates an object that can be returned from `inactivate` function.
+   * If an `action` returns `context.cancel()`, it will be considered as no return value.
    *
    * NOTE: `inactivate` is considered to be an internal router feature, for the examples, refer to the router tests.
    *

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -167,9 +167,9 @@
         it('inactivate chain is called in reversed order, from last route to first', async() => {
           const deactivatedPaths = [];
           router.setRoutes([
-            {path: '/a', inactivate: context => deactivatedPaths.push(context.invocationPath.path), children: [
-              {path: '/b', inactivate: context => deactivatedPaths.push(context.invocationPath.path), children: [
-                {path: '/c', inactivate: context => deactivatedPaths.push(context.invocationPath.path), component: 'x-users-view'},
+            {path: '/a', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), children: [
+              {path: '/b', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), children: [
+                {path: '/c', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), component: 'x-users-view'},
               ]},
             ]},
             {path: '/', component: 'x-home-view'},
@@ -201,8 +201,8 @@
           expect(contextParam.pathname).to.equal(lastResolvedRoute);
           expect(contextParam.route.path).to.equal(lastResolvedRoute);
           expect(contextParam.route.component).to.equal(lastComponentToRender);
-          expect(contextParam.invocationPath.path).to.equal('/a');
-          expect(contextParam.invocationPath.component).to.equal('x-home-view');
+          expect(contextParam.invocationRoute.path).to.equal('/a');
+          expect(contextParam.invocationRoute.component).to.equal('x-home-view');
         });
 
         it('inactivate is not called for same routes in new resolve pass', async() => {

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -351,6 +351,25 @@
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
+
+        it('action with redirect gets double slashes removed from its context.from and redirect.from', async() => {
+          let from = '';
+          router.setRoutes([
+            {path: '/', children: [
+              {path: '', children: [
+                {path: '/c', action: context => context.redirect('/d')}
+              ]},
+            ]},
+            {path: '/d', component: 'x-home-view', action: context => {
+              from = context.from;
+            }}
+          ]);
+
+          await router.render('/c');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          expect(from).to.be.equal('/c');
+        });
       });
     });
 

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -167,9 +167,15 @@
         it('inactivate chain is called in reversed order, from last route to first', async() => {
           const deactivatedPaths = [];
           router.setRoutes([
-            {path: '/a', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), children: [
-              {path: '/b', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), children: [
-                {path: '/c', inactivate: context => deactivatedPaths.push(context.invocationRoute.path), component: 'x-users-view'},
+            {path: '/a', inactivate: function() {
+              deactivatedPaths.push(this.path);
+            }, children: [
+              {path: '/b', inactivate: function() {
+                deactivatedPaths.push(this.path);
+              }, children: [
+                {path: '/c', component: 'x-users-view', inactivate: function() {
+                  deactivatedPaths.push(this.path);
+                }},
               ]},
             ]},
             {path: '/', component: 'x-home-view'},
@@ -201,8 +207,24 @@
           expect(contextParam.pathname).to.equal(lastResolvedRoute);
           expect(contextParam.route.path).to.equal(lastResolvedRoute);
           expect(contextParam.route.component).to.equal(lastComponentToRender);
-          expect(contextParam.invocationRoute.path).to.equal('/a');
-          expect(contextParam.invocationRoute.component).to.equal('x-home-view');
+        });
+
+        it('inactivate.this points to the route that defines action', async() => {
+          router.setRoutes([
+            {path: '/a', component: 'x-home-view', inactivate: function(context) {
+              expect(this.path).to.equal('/a');
+              expect(this.component).to.equal('x-home-view');
+              expect(this).not.to.be.equal(context.route);
+              expect(context.route.path).to.be.equal('/b');
+              expect(context.route.component).to.be.equal('x-users-view');
+            }},
+            {path: '/b', component: 'x-users-view'},
+          ]);
+
+          await router.render('/a');
+          await router.render('/b');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
         });
 
         it('inactivate is not called for same routes in new resolve pass', async() => {

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -167,9 +167,9 @@
         it('inactivate chain is called in reversed order, from last route to first', async() => {
           const deactivatedPaths = [];
           router.setRoutes([
-            {path: '/a', inactivate: context => deactivatedPaths.push(context.inactivatedRoute.path), children: [
-              {path: '/b', inactivate: context => deactivatedPaths.push(context.inactivatedRoute.path), children: [
-                {path: '/c', inactivate: context => deactivatedPaths.push(context.inactivatedRoute.path), component: 'x-users-view'},
+            {path: '/a', inactivate: context => deactivatedPaths.push(context.invocationPath.path), children: [
+              {path: '/b', inactivate: context => deactivatedPaths.push(context.invocationPath.path), children: [
+                {path: '/c', inactivate: context => deactivatedPaths.push(context.invocationPath.path), component: 'x-users-view'},
               ]},
             ]},
             {path: '/', component: 'x-home-view'},
@@ -190,6 +190,9 @@
           ]);
 
           await router.render('/a');
+
+          expect(inactivateFunction).to.not.have.been.called;
+
           await router.render(lastResolvedRoute);
 
           expect(inactivateFunction).to.have.been.called.once;
@@ -198,8 +201,8 @@
           expect(contextParam.pathname).to.equal(lastResolvedRoute);
           expect(contextParam.route.path).to.equal(lastResolvedRoute);
           expect(contextParam.route.component).to.equal(lastComponentToRender);
-          expect(contextParam.inactivatedRoute.path).to.equal('/a');
-          expect(contextParam.inactivatedRoute.component).to.equal('x-home-view');
+          expect(contextParam.invocationPath.path).to.equal('/a');
+          expect(contextParam.invocationPath.component).to.equal('x-home-view');
         });
 
         it('inactivate is not called for same routes in new resolve pass', async() => {
@@ -289,6 +292,42 @@
 
           expect(outlet.children[0].tagName).to.match(/x-users-view/i);
           verifyActiveRoutes(router, ['/a', '/b']);
+        });
+      });
+
+      describe('redirect.from and context.from values for dynamic redirects', () => {
+        let router;
+        beforeEach(() => {
+          router = new Vaadin.Router(outlet);
+        });
+
+        afterEach(() => {
+          router.unsubscribe();
+        });
+
+        const from = '/a/b/c';
+        const redirectFunction = context => {
+          const redirectObject = context.redirect('/d');
+          expect(redirectObject.redirect.from).to.be.equal(from);
+          return redirectObject;
+        };
+        const verificationAction = context => {
+          expect(context.from).to.be.equal(from);
+        };
+
+        it('action with redirect has its context.from and redirect.from populated correctly', async() => {
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', children: [
+                {path: '/c', action: redirectFunction}
+              ]},
+            ]},
+            {path: '/d', component: 'x-home-view', action: verificationAction}
+          ]);
+
+          await router.render(from);
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
       });
 

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -291,6 +291,38 @@
           verifyActiveRoutes(router, ['/a', '/b']);
         });
       });
+
+      describe('recursive redirects', () => {
+        let router;
+        beforeEach(() => {
+          router = new Vaadin.Router(outlet);
+        });
+
+        afterEach(() => {
+          router.unsubscribe();
+        });
+
+        it('recursive redirect defined with property works and activates the path once', async() => {
+          router.setRoutes([
+            {path: '/', redirect: '/', component: 'x-home-view'}
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('recursive redirect caused by action works and activates the path once', async() => {
+          router.setRoutes([
+            {path: '/', action: context => context.redirect('/'), component: 'x-home-view'}
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          verifyActiveRoutes(router, ['/']);
+        });
+      });
     });
 
     function verifyActiveRoutes(router, expectedSegments) {

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -330,38 +330,6 @@
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
       });
-
-      describe('recursive redirects', () => {
-        let router;
-        beforeEach(() => {
-          router = new Vaadin.Router(outlet);
-        });
-
-        afterEach(() => {
-          router.unsubscribe();
-        });
-
-        it('recursive redirect defined with property works and activates the path once', async() => {
-          router.setRoutes([
-            {path: '/', redirect: '/', component: 'x-home-view'}
-          ]);
-
-          await router.render('/');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-        });
-
-        it('recursive redirect caused by action works and activates the path once', async() => {
-          router.setRoutes([
-            {path: '/', action: context => context.redirect('/'), component: 'x-home-view'}
-          ]);
-
-          await router.render('/');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, ['/']);
-        });
-      });
     });
 
     function verifyActiveRoutes(router, expectedSegments) {

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -583,8 +583,8 @@
             expect(contextParam.pathname).to.equal('/');
             expect(contextParam.route.path).to.equal('/');
             expect(contextParam.route.component).to.equal('x-home-view');
-            expect(contextParam.invocationPath.path).to.equal('/');
-            expect(contextParam.invocationPath.component).to.equal('x-home-view');
+            expect(contextParam.invocationRoute.path).to.equal('/');
+            expect(contextParam.invocationRoute.component).to.equal('x-home-view');
           });
 
           it('should throw on incorrect bundle path', async() => {

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -569,6 +569,24 @@
             expect(getBundleScripts(existingBundlePath).length).to.equal(1);
           });
 
+          it('action should be called with correct parameters', async() => {
+            const action = sinon.spy();
+            router.setRoutes([
+              {path: '/', component: 'x-home-view', action: action}
+            ]);
+
+            await router.render('/');
+
+            expect(action).to.have.been.called.once;
+            expect(action.args[0].length).to.equal(1);
+            const contextParam = action.args[0][0];
+            expect(contextParam.pathname).to.equal('/');
+            expect(contextParam.route.path).to.equal('/');
+            expect(contextParam.route.component).to.equal('x-home-view');
+            expect(contextParam.invocationPath.path).to.equal('/');
+            expect(contextParam.invocationPath.component).to.equal('x-home-view');
+          });
+
           it('should throw on incorrect bundle path', async() => {
             const nonExistingPath = 'does-not-exist.js';
             router.setRoutes([

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -771,6 +771,17 @@
 
             expect(outlet.children[0].tagName).to.match(/x-users-view/i);
           });
+
+          it('context.redirect() should work when invoked without the `this` context', async() => {
+            router.setRoutes([
+              {path: '/', component: 'x-home-view'},
+              {path: '/a', action: ({redirect}) => redirect('/')}
+            ]);
+
+            await router.render('/a');
+
+            expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          });
         });
       });
     });

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -583,8 +583,20 @@
             expect(contextParam.pathname).to.equal('/');
             expect(contextParam.route.path).to.equal('/');
             expect(contextParam.route.component).to.equal('x-home-view');
-            expect(contextParam.invocationRoute.path).to.equal('/');
-            expect(contextParam.invocationRoute.component).to.equal('x-home-view');
+          });
+
+          it('action.this points to the route that defines action', async() => {
+            router.setRoutes([
+              {path: '/', component: 'x-home-view', action: function(context) {
+                expect(this.path).to.equal('/');
+                expect(this.component).to.equal('x-home-view');
+                expect(this).to.be.equal(context.route);
+              }}
+            ]);
+
+            await router.render('/');
+
+            expect(outlet.children[0].tagName).to.match(/x-home-view/i);
           });
 
           it('should throw on incorrect bundle path', async() => {


### PR DESCRIPTION
Based on https://github.com/vaadin/vaadin-router/pull/137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/138)
<!-- Reviewable:end -->
