### PR TITLE
Support `onBeforeEnter`, `onBeforeLeave` and `onAfterEnter` navigation lifecycle events.

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -36,7 +36,7 @@ function renderComponent(context, component) {
   return element;
 }
 
-function runCallbackIfPossible(callback, context, invocationRoute) {
+function runCallbackIfPossible(callback, context, invocationRoute, thisObject) {
   if (typeof callback === 'function') {
     const updatedContext = Object.assign({}, context, {
       __invocationRoute: invocationRoute,
@@ -44,7 +44,7 @@ function runCallbackIfPossible(callback, context, invocationRoute) {
       component: component => renderComponent(updatedContext, component),
       cancel: () => ({cancel: true})
     });
-    return callback.call(invocationRoute, updatedContext);
+    return callback.call(thisObject, updatedContext);
   }
 }
 
@@ -146,7 +146,7 @@ export class Router extends Resolver {
   __resolveRoute(context) {
     const route = context.route;
 
-    const actionResult = runCallbackIfPossible(processAction, context, route);
+    const actionResult = runCallbackIfPossible(processAction, context, route, route);
     if (isResultNotEmpty(actionResult) && !actionResult.cancel) {
       return actionResult;
     }

--- a/test/resolver/resolver.spec.js
+++ b/test/resolver/resolver.spec.js
@@ -179,6 +179,16 @@
       expect(context.result).to.be.true;
     });
 
+    it('resolver skips the path in chain when context.next() is called', async() => {
+      const resolver = new Resolver([
+        {path: '/a', action: context => context.next()},
+        {path: '/a', action: () => true},
+      ]);
+      const context = await resolver.resolve({pathname: '/a'});
+      expect(context.chain).to.be.an('array').lengthOf(1);
+      expect(context.chain[0].path).to.equal('/a');
+    });
+
     it('the path to the route that produced the result is in the `context` (1))', async() => {
       const resolver = new Resolver([{path: '/:one/:two', action: () => true}]);
       const context = await resolver.resolve({pathname: '/a/b'});

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -38,7 +38,7 @@
         return throttler.throttle(test);
       });
 
-      describe('active routes', () => {
+      describe('resolver chain and router features', () => {
         let router;
         beforeEach(() => {
           router = new Vaadin.Router(outlet);
@@ -46,27 +46,6 @@
 
         afterEach(() => {
           router.unsubscribe();
-        });
-
-        it('paths without parameters should have each route activated', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', children: [
-                {path: '/c', component: 'x-home-view'}
-              ]},
-              {path: '/', component: 'x-home-view'},
-            ]},
-            {path: '/d', component: 'x-home-view'}
-          ]);
-
-          await router.render('/a/b/c');
-          verifyActiveRoutes(router, ['/a', '/b', '/c']);
-
-          await router.render('/d');
-          verifyActiveRoutes(router, ['/d']);
-
-          await router.render('/a');
-          verifyActiveRoutes(router, ['/a', '/']);
         });
 
         it('paths with parameters should have each route activated without parameters replaced', async() => {
@@ -112,20 +91,6 @@
           verifyActiveRoutes(router, ['/']);
         });
 
-        it('action that uses context.next() overrides inactivate for the same route', async() => {
-          const inactivate = sinon.spy();
-          router.setRoutes([
-            {path: '/', action: context => context.next(), inactivate: inactivate},
-            {path: '/', component: 'x-home-view'},
-            {path: '/b', component: 'x-users-view'},
-          ]);
-
-          await router.render('/');
-          await router.render('/b');
-
-          expect(inactivate).to.not.have.been.called;
-        });
-
         it('action that returns custom component activates route', async() => {
           router.setRoutes([
             {path: '/', action: context => context.component('x-home-view')},
@@ -147,286 +112,9 @@
           verifyActiveRoutes(router, ['/a']);
           expect(outlet.children[0].tagName).to.match(/x-users-view/i);
         });
-
-        it('inactivate is called on deactivation and does not interrupt render if returns no value', async() => {
-          const inactivate = sinon.spy();
-          router.setRoutes([
-            {path: '/a', component: 'x-home-view', inactivate: inactivate},
-            {path: '/b', component: 'x-users-view'},
-          ]);
-
-          await router.render('/a');
-          expect(inactivate).to.not.have.been.called;
-
-          await router.render('/b');
-          expect(inactivate).to.have.been.called.once;
-          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
-          verifyActiveRoutes(router, ['/b']);
-        });
-
-        it('inactivate chain is called in reversed order, from last route to first', async() => {
-          const inactivations = [];
-          router.setRoutes([
-            {
-              path: '/',
-              inactivate: () => {
-                inactivations.push('L1');
-              },
-              children: [
-                {
-                  path: '',
-                  inactivate: () => {
-                    inactivations.push('L2');
-                  },
-                  children: [
-                    {
-                      path: 'a',
-                      inactivate: () => {
-                        inactivations.push('L3');
-                      },
-                      component: 'x-users-view'
-                    }
-                  ]
-                },
-              ]
-            },
-            {path: '/b', component: 'x-home-view'}
-          ]);
-
-          await router.render('/a');
-          await router.render('/b');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          expect(inactivations).to.deep.equal(['L3', 'L2', 'L1']);
-        });
-
-        it('inactivate promises return result are supported', async() => {
-          const inactivations = [];
-          router.setRoutes([
-            {
-              path: '/a',
-              inactivate: context => new Promise(resolve => {
-                inactivations.push('L1');
-                resolve(context.cancel());
-              }),
-              children: [
-                {
-                  path: '/b',
-                  component: 'x-users-list',
-                  inactivate: () => new Promise(resolve => {
-                    inactivations.push('L2');
-                    resolve();
-                  }),
-                },
-              ]
-            },
-            {path: '/c', component: 'x-home-view'}
-          ]);
-
-          await router.render('/a/b');
-          await router.render('/c');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
-          expect(inactivations).to.deep.equal(['L2', 'L1']);
-        });
-
-        it('inactivate is called with correct context argument', async() => {
-          const lastResolvedRoute = '/b';
-          const lastComponentToRender = 'x-users-view';
-          const inactivateFunction = sinon.spy();
-          router.setRoutes([
-            {path: '/a', component: 'x-home-view', inactivate: inactivateFunction},
-            {path: lastResolvedRoute, component: lastComponentToRender},
-          ]);
-
-          await router.render('/a');
-
-          expect(inactivateFunction).to.not.have.been.called;
-
-          await router.render(lastResolvedRoute);
-
-          expect(inactivateFunction).to.have.been.called.once;
-          expect(inactivateFunction.args[0].length).to.equal(1);
-          const contextParam = inactivateFunction.args[0][0];
-          expect(contextParam.pathname).to.equal(lastResolvedRoute);
-          expect(contextParam.route.path).to.equal(lastResolvedRoute);
-          expect(contextParam.route.component).to.equal(lastComponentToRender);
-        });
-
-        it('inactivate.this points to the route that defines action', async() => {
-          router.setRoutes([
-            {path: '/a', component: 'x-home-view', inactivate: function(context) {
-              expect(this.path).to.equal('/a');
-              expect(this.component).to.equal('x-home-view');
-              expect(this).not.to.be.equal(context.route);
-              expect(context.route.path).to.be.equal('/b');
-              expect(context.route.component).to.be.equal('x-users-view');
-            }},
-            {path: '/b', component: 'x-users-view'},
-          ]);
-
-          await router.render('/a');
-          await router.render('/b');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
-        });
-
-        it('inactivate is not called for same routes in new resolve pass', async() => {
-          const inactivateA = sinon.spy();
-          const inactivateB = sinon.spy();
-          const inactivateC = sinon.spy();
-
-          router.setRoutes([
-            {path: '/a', inactivate: inactivateA, children: [
-              {path: '/b', inactivate: inactivateB, children: [
-                {path: '/c', inactivate: inactivateC, component: 'x-home-view'}
-              ]},
-              {path: '/', component: 'x-home-view'},
-            ]},
-          ]);
-
-          await router.render('/a/b/c');
-          await router.render('/a');
-
-          expect(inactivateA).to.not.have.been.called;
-          expect(inactivateB).to.have.been.called.once;
-          expect(inactivateC).to.have.been.called.once;
-        });
-
-        it('inactivate that returns cancel, changes render target and reverts active routes changes every time it is triggered', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', inactivate: context => context.cancel(), children: [
-                {path: '/c', component: 'x-home-view'}
-              ]},
-            ]},
-            {path: '/d', component: 'whatever'}
-          ]);
-
-          await router.render('/a/b/c');
-          await router.render('/d');
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, ['/a', '/b', '/c']);
-
-          await router.render('/d');
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, ['/a', '/b', '/c']);
-        });
-
-        it('inactivate is called when new activation path has no different routes but is shorter', async() => {
-          const inactivate = sinon.spy();
-          const actionToEmulateShorterResolvePass = context => {
-            if ((context.pathname.match(/\//g) || []).length < 2) {
-              return context.component('x-home-view');
-            }
-          };
-          router.setRoutes([
-            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
-              {path: '/b', component: 'x-users-view', inactivate: inactivate},
-            ]},
-          ]);
-
-          await router.render('/a/b');
-          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
-          verifyActiveRoutes(router, ['/a', '/b']);
-          expect(inactivate).to.not.have.been.called;
-
-          await router.render('/a');
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, ['/a']);
-          expect(inactivate).to.have.been.called.once;
-        });
-
-        it('inactivate that returns cancel, changes render target and reverts active routes changes ' +
-          'when new activation path has no different routes but is shorter', async() => {
-          const actionToEmulateShorterResolvePass = context => {
-            if ((context.pathname.match(/\//g) || []).length < 2) {
-              return context.component('x-home-view');
-            }
-          };
-          router.setRoutes([
-            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
-              {path: '/b', component: 'x-users-view', inactivate: context => context.cancel()},
-            ]},
-          ]);
-
-          await router.render('/a/b');
-          await router.render('/a');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
-          verifyActiveRoutes(router, ['/a', '/b']);
-        });
       });
 
-      describe('redirect.from and context.from values for dynamic redirects', () => {
-        let router;
-        beforeEach(() => {
-          router = new Vaadin.Router(outlet);
-        });
-
-        afterEach(() => {
-          router.unsubscribe();
-        });
-
-        const from = '/a/b/c';
-        const redirectFunction = context => {
-          const redirectObject = context.redirect('/d');
-          expect(redirectObject.redirect.from).to.be.equal(from);
-          return redirectObject;
-        };
-        const verificationAction = context => {
-          expect(context.from).to.be.equal(from);
-        };
-
-        it('action with redirect has its context.from and redirect.from populated correctly', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', children: [
-                {path: '/c', action: redirectFunction}
-              ]},
-            ]},
-            {path: '/d', component: 'x-home-view', action: verificationAction}
-          ]);
-
-          await router.render(from);
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-        });
-
-        it('onBeforeEnter with redirect has its context.from and redirect.from populated correctly', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', children: [
-                {path: '/c', action: onBeforeEnterAction('whatever', redirectFunction)}
-              ]},
-            ]},
-            {path: '/d', component: 'x-home-view', action: verificationAction}
-          ]);
-
-          await router.render(from);
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-        });
-
-        it('onBeforeLeave with redirect has its context.from and redirect.from populated correctly', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', children: [
-                {path: '/c', action: onBeforeLeaveAction('x-users-list', redirectFunction)}
-              ]},
-            ]},
-            {path: '/d', component: 'x-home-view', action: verificationAction},
-            {path: '/e', component: 'x-users-list'},
-          ]);
-
-          await router.render(from);
-          await router.render('/e');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-        });
-      });
-
-      describe('onBeforeEnter and onBeforeLeave', () => {
+      describe('onBeforeEnter, onBeforeLeave and onAfterEnter', () => {
         let router;
         beforeEach(() => {
           router = new Vaadin.Router(outlet);
@@ -449,6 +137,9 @@
           const contextParam = onBeforeEnter.args[0][0];
           expect(contextParam.pathname).to.equal('/');
           expect(contextParam.route.path).to.equal('/');
+          expect(contextParam.cancel).to.be.a('function');
+          expect(contextParam.redirect).to.be.an('undefined');
+          expect(contextParam.component).to.be.an('undefined');
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
@@ -457,13 +148,11 @@
           router.setRoutes([
             {path: '/', action: onBeforeEnterAction('x-home-view', function() {
               // eslint-disable-next-line no-invalid-this
-              expect(this).to.be.a('HTMLElement');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.tagName.toLowerCase()).to.equal('x-home-view');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.onBeforeEnter).not.to.be.a('null');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.onBeforeLeave).to.be.an('undefined');
+              const current = this;
+              expect(current).to.be.a('HTMLElement');
+              expect(current.tagName.toLowerCase()).to.equal('x-home-view');
+              expect(current.onBeforeEnter).not.to.be.a('null');
+              expect(current.onBeforeLeave).to.be.an('undefined');
             })},
           ]);
 
@@ -487,8 +176,11 @@
           expect(onBeforeLeave).to.have.been.called.once;
           expect(onBeforeLeave.args[0].length).to.equal(1);
           const contextParam = onBeforeLeave.args[0][0];
-          expect(contextParam.pathname).to.equal('/');
-          expect(contextParam.route.path).to.equal('/');
+          expect(contextParam.pathname).to.equal('/users');
+          expect(contextParam.route.path).to.equal('/users');
+          expect(contextParam.cancel).to.be.a('function');
+          expect(contextParam.redirect).to.be.an('undefined');
+          expect(contextParam.component).to.be.an('undefined');
 
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
@@ -497,13 +189,11 @@
           router.setRoutes([
             {path: '/', action: onBeforeLeaveAction('x-home-view', function() {
               // eslint-disable-next-line no-invalid-this
-              expect(this).to.be.a('HTMLElement');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.tagName.toLowerCase()).to.equal('x-home-view');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.onBeforeLeave).not.to.be.a('null');
-              // eslint-disable-next-line no-invalid-this
-              expect(this.onBeforeEnter).to.be.an('undefined');
+              const current = this;
+              expect(current).to.be.a('HTMLElement');
+              expect(current.tagName.toLowerCase()).to.equal('x-home-view');
+              expect(current.onBeforeLeave).not.to.be.a('null');
+              expect(current.onBeforeEnter).to.be.an('undefined');
             })},
             {path: '/users', component: 'x-users-list'},
           ]);
@@ -514,102 +204,87 @@
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
 
-        it('action, onBeforeEnter and onBeforeLeave are called in correct order', async() => {
-          let invocations = [];
+        it('onAfterEnter is called with correct parameters', async() => {
+          const onBeforeEnter = sinon.spy();
+          router.setRoutes([
+            {path: '/', action: onAfterEnterAction('x-home-view', onBeforeEnter)}
+          ]);
+
+          await router.render('/');
+
+          expect(onBeforeEnter).to.have.been.called.once;
+          expect(onBeforeEnter.args[0].length).to.equal(1);
+          const contextParam = onBeforeEnter.args[0][0];
+          expect(contextParam.pathname).to.equal('/');
+          expect(contextParam.route.path).to.equal('/');
+          expect(contextParam.cancel).to.be.an('undefined');
+          expect(contextParam.redirect).to.be.an('undefined');
+          expect(contextParam.component).to.be.an('undefined');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('onAfterEnter.this points to the component that has defines the property', async() => {
+          router.setRoutes([
+            {path: '/', action: onAfterEnterAction('x-home-view', function() {
+              // eslint-disable-next-line no-invalid-this
+              const current = this;
+              expect(current).to.be.a('HTMLElement');
+              expect(current.tagName.toLowerCase()).to.equal('x-home-view');
+              expect(current.onBeforeEnter).not.to.be.a('null');
+              expect(current.onBeforeLeave).to.be.an('undefined');
+            })},
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('action, onBeforeEnter, onBeforeLeave and onAfterEnter are called in correct order', async() => {
+          const invocations = [];
           router.setRoutes([
             {
-              path: '/',
+              path: '/a',
               action: context => {
+                invocations.push('actionA');
+
                 const component = context.component('x-home-view');
                 component.onBeforeLeave = () => {
-                  invocations.push('onBeforeLeave');
+                  invocations.push('onBeforeLeaveA');
                 };
                 component.onBeforeEnter = () => {
-                  invocations = [];
-                  invocations.push('onBeforeEnter');
+                  invocations.push('onBeforeEnterA');
+                };
+                component.onAfterEnter = () => {
+                  invocations.push('onAfterEnterA');
                 };
                 return component;
               },
-              inactivate: () => {
-                invocations.push('inactivate');
-              }
             },
-            {path: '/users', component: 'x-users-list', action: () => {
-              invocations.push('action');
+            {path: '/b', action: context => {
+              invocations.push('actionB');
+
+              const component = context.component('x-users-list');
+              component.onBeforeLeave = () => {
+                invocations.push('onBeforeLeaveB');
+              };
+              component.onBeforeEnter = () => {
+                invocations.push('onBeforeEnterB');
+              };
+              component.onAfterEnter = () => {
+                invocations.push('onAfterEnterB');
+              };
+              return component;
             }},
           ]);
 
-          await router.render('/');
-          expect(invocations).to.deep.equal(['onBeforeEnter']);
+          await router.render('/a');
+          expect(invocations).to.deep.equal(['actionA', 'onBeforeEnterA', 'onAfterEnterA']);
 
-          await router.render('/users');
-          expect(invocations).to.deep.equal(['onBeforeEnter', 'onBeforeLeave', 'action']);
-        });
-
-        it('when onBeforeEnter returns an HTMLElement, the element is rendered and now route is activated', async() => {
-          router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('whatever', context => context.component('x-users-list'))}
-          ]);
-
-          await router.render('/');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
-          verifyActiveRoutes(router, []);
-        });
-
-        it('when onBeforeLeave returns an HTMLElement, the element is rendered and activation chain is not changed', async() => {
-          router.setRoutes([
-            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.component('x-users-list'))},
-            {path: '/test', component: 'whatever'}
-          ]);
-
-          await router.render('/');
-          await router.render('/test');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
-          verifyActiveRoutes(router, []);
-        });
-
-        it('when onBeforeEnter returns a redirect, the redirect target is rendered and activated', async() => {
-          router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('whatever', context => context.redirect('/users'))},
-            {path: '/users', component: 'x-users-list'}
-          ]);
-
-          await router.render('/');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
-          verifyActiveRoutes(router, ['/users']);
-        });
-
-        it('when onBeforeLeave returns a redirect, the redirect target is rendered and activated', async() => {
-          router.setRoutes([
-            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.redirect('/test'))},
-            {path: '/users', component: 'x-users-list'},
-            {path: '/test', component: 'x-image-view'}
-          ]);
-
-          await router.render('/');
-          await router.render('/users');
-
-          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
-          verifyActiveRoutes(router, ['/test']);
-        });
-
-        it('when onBeforeEnter returns cancel and there is no previous state, an error is thrown', async() => {
-          const path = '/';
-          router.setRoutes([
-            {path: path, action: onBeforeEnterAction('whatever', context => context.cancel())},
-          ]);
-
-          let exceptionThrown = false;
-          try {
-            await router.render(path);
-          } catch (e) {
-            expect(e.message).to.contain(path);
-            exceptionThrown = true;
-          }
-          expect(exceptionThrown).to.equal(true);
+          await router.render('/b');
+          expect(invocations).to.deep.equal(
+            ['actionA', 'onBeforeEnterA', 'onAfterEnterA', 'actionB', 'onBeforeLeaveA', 'onBeforeEnterB', 'onAfterEnterB']);
         });
 
         it('when onBeforeEnter returns cancel, resolution is aborted and reverted to the previous state', async() => {
@@ -635,140 +310,61 @@
           await router.render('/users');
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, []);
+          verifyActiveRoutes(router, ['/']);
         });
 
-        it('inactivate overrides onBeforeEnter', async() => {
+        it('when onBeforeEnter, onBeforeLeave and onAfterEnter return any non-cancel value, it is ignored', async() => {
           router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', inactivate: context => context.cancel(), children: [
-                {path: '/c', component: 'x-home-view'}
-              ]},
-            ]},
-            {path: '/d', action: onBeforeEnterAction('x-users-list', context => context.component('x-image-view'))},
+            {
+              path: '/a',
+              action: context => {
+                const component = context.component('x-home-view');
+                component.onBeforeLeave = () => true;
+                component.onBeforeEnter = () => 42;
+                component.onAfterEnter = () => [];
+                return component;
+              },
+            },
+            {path: '/b', component: 'x-users-list'},
           ]);
 
-          await router.render('/a/b/c');
-          await router.render('/d');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          verifyActiveRoutes(router, ['/a', '/b', '/c']);
-        });
-
-        it('inactivate overrides onBeforeEnter for same route but shorter', async() => {
-          const actionToEmulateShorterResolvePass = context => {
-            if ((context.pathname.match(/\//g) || []).length < 2) {
-              const component = context.component('x-home-view');
-              component.onBeforeEnter = context => context.component('x-image-view');
-              return component;
-            }
-          };
-          router.setRoutes([
-            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
-              {path: '/b', component: 'x-users-view', inactivate: context => context.cancel()},
-            ]},
-          ]);
-
-          await router.render('/a/b');
           await router.render('/a');
-
-          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
-          verifyActiveRoutes(router, ['/a', '/b']);
+          await router.render('/b');
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+          verifyActiveRoutes(router, ['/b']);
         });
 
-        it('onBeforeLeave overrides inactivate', async() => {
-          const inactivate = sinon.spy();
+        it('promises are possible in onBeforeEnter, onBeforeLeave and onAfterEnter', async() => {
+          const invocations = [];
           router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', inactivate: inactivate, children: [
-                {path: '/c', action: onBeforeLeaveAction('x-home-view', context => context.component('x-image-view'))}
-              ]},
-            ]},
-            {path: '/d', component: 'x-users-list'},
+            {
+              path: '/a',
+              action: context => {
+                const component = context.component('x-home-view');
+                component.onBeforeLeave = context => new Promise(resolve => {
+                  invocations.push('onBeforeLeave');
+                  return resolve(context.cancel());
+                });
+                component.onBeforeEnter = () => new Promise(resolve => {
+                  invocations.push('onBeforeEnter');
+                  return resolve();
+                });
+                component.onAfterEnter = () => new Promise(resolve => {
+                  invocations.push('onAfterEnter');
+                  return resolve();
+                });
+                return component;
+              },
+            },
+            {path: '/b', component: 'x-users-list'},
           ]);
 
-          await router.render('/a/b/c');
-          await router.render('/d');
-
-          expect(inactivate).to.not.have.been.called;
-          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
-          verifyActiveRoutes(router, ['/a', '/b']);
-        });
-
-        it('onBeforeLeave overrides inactivate for same route but shorter', async() => {
-          const inactivate = sinon.spy();
-          const actionToEmulateShorterResolvePass = context => {
-            if ((context.pathname.match(/\//g) || []).length < 2) {
-              return context.component('x-home-view');
-            }
-          };
-          router.setRoutes([
-            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
-              {path: '/b', inactivate: inactivate, action: onBeforeLeaveAction('x-users-view', context => context.component('x-image-view'))},
-            ]},
-          ]);
-
-          await router.render('/a/b');
           await router.render('/a');
+          expect(invocations).to.deep.equal(['onBeforeEnter', 'onAfterEnter']);
 
-          expect(inactivate).to.not.have.been.called;
-          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
-          verifyActiveRoutes(router, ['/a']);
-        });
-      });
-
-      describe('redirect.from and context.from values for dynamic redirects', () => {
-        let router;
-        beforeEach(() => {
-          router = new Vaadin.Router(outlet);
-        });
-
-        afterEach(() => {
-          router.unsubscribe();
-        });
-
-        const from = '/a/b/c';
-        const redirectFunction = context => {
-          const redirectObject = context.redirect('/d');
-          expect(redirectObject.redirect.from).to.be.equal(from);
-          return redirectObject;
-        };
-        const verificationAction = context => {
-          expect(context.from).to.be.equal(from);
-        };
-
-        it('action with redirect has its context.from and redirect.from populated correctly', async() => {
-          router.setRoutes([
-            {path: '/a', children: [
-              {path: '/b', children: [
-                {path: '/c', action: redirectFunction}
-              ]},
-            ]},
-            {path: '/d', component: 'x-home-view', action: verificationAction}
-          ]);
-
-          await router.render(from);
-
+          await router.render('/b');
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-        });
-
-        it('action with redirect gets double slashes removed from its context.from and redirect.from', async() => {
-          let from = '';
-          router.setRoutes([
-            {path: '/', children: [
-              {path: '', children: [
-                {path: '/c', action: context => context.redirect('/d')}
-              ]},
-            ]},
-            {path: '/d', component: 'x-home-view', action: context => {
-              from = context.from;
-            }}
-          ]);
-
-          await router.render('/c');
-
-          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          expect(from).to.be.equal('/c');
+          expect(invocations).to.deep.equal(['onBeforeEnter', 'onAfterEnter', 'onBeforeLeave']);
         });
       });
     });
@@ -785,6 +381,14 @@
       return context => {
         const component = context.component(componentName);
         component.onBeforeEnter = callback;
+        return component;
+      };
+    }
+
+    function onAfterEnterAction(componentName, callback) {
+      return context => {
+        const component = context.component(componentName);
+        component.onAfterEnter = callback;
         return component;
       };
     }

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -453,13 +453,17 @@
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
 
-        it('onBeforeEnter.this points to the route that defines the component', async() => {
+        it('onBeforeEnter.this points to the component that has defines the property', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('x-home-view', function(context) {
+            {path: '/', action: onBeforeEnterAction('x-home-view', function() {
               // eslint-disable-next-line no-invalid-this
-              expect(this.path).to.equal('/');
+              expect(this).to.be.a('HTMLElement');
               // eslint-disable-next-line no-invalid-this
-              expect(this).to.be.equal(context.route);
+              expect(this.tagName.toLowerCase()).to.equal('x-home-view');
+              // eslint-disable-next-line no-invalid-this
+              expect(this.onBeforeEnter).not.to.be.a('null');
+              // eslint-disable-next-line no-invalid-this
+              expect(this.onBeforeLeave).to.be.an('undefined');
             })},
           ]);
 
@@ -489,13 +493,17 @@
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
 
-        it('onBeforeLeave.this points to the route that defines the component', async() => {
+        it('onBeforeLeave.this points to the component that has defines the property', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeLeaveAction('x-home-view', function(context) {
+            {path: '/', action: onBeforeLeaveAction('x-home-view', function() {
               // eslint-disable-next-line no-invalid-this
-              expect(this.path).to.equal('/');
+              expect(this).to.be.a('HTMLElement');
               // eslint-disable-next-line no-invalid-this
-              expect(this).to.be.equal(context.route);
+              expect(this.tagName.toLowerCase()).to.equal('x-home-view');
+              // eslint-disable-next-line no-invalid-this
+              expect(this.onBeforeLeave).not.to.be.a('null');
+              // eslint-disable-next-line no-invalid-this
+              expect(this.onBeforeEnter).to.be.an('undefined');
             })},
             {path: '/users', component: 'x-users-list'},
           ]);

--- a/test/router/dynamic.redirect.spec.html
+++ b/test/router/dynamic.redirect.spec.html
@@ -393,6 +393,357 @@
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
 
+        it('onBeforeEnter with redirect has its context.from and redirect.from populated correctly', async() => {
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', children: [
+                {path: '/c', action: onBeforeEnterAction('whatever', redirectFunction)}
+              ]},
+            ]},
+            {path: '/d', component: 'x-home-view', action: verificationAction}
+          ]);
+
+          await router.render(from);
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('onBeforeLeave with redirect has its context.from and redirect.from populated correctly', async() => {
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', children: [
+                {path: '/c', action: onBeforeLeaveAction('x-users-list', redirectFunction)}
+              ]},
+            ]},
+            {path: '/d', component: 'x-home-view', action: verificationAction},
+            {path: '/e', component: 'x-users-list'},
+          ]);
+
+          await router.render(from);
+          await router.render('/e');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+      });
+
+      describe('onBeforeEnter and onBeforeLeave', () => {
+        let router;
+        beforeEach(() => {
+          router = new Vaadin.Router(outlet);
+        });
+
+        afterEach(() => {
+          router.unsubscribe();
+        });
+
+        it('onBeforeEnter is called with correct parameters', async() => {
+          const onBeforeEnter = sinon.spy();
+          router.setRoutes([
+            {path: '/', action: onBeforeEnterAction('x-home-view', onBeforeEnter)}
+          ]);
+
+          await router.render('/');
+
+          expect(onBeforeEnter).to.have.been.called.once;
+          expect(onBeforeEnter.args[0].length).to.equal(1);
+          const contextParam = onBeforeEnter.args[0][0];
+          expect(contextParam.pathname).to.equal('/');
+          expect(contextParam.route.path).to.equal('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('onBeforeEnter.this points to the route that defines the component', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeEnterAction('x-home-view', function(context) {
+              // eslint-disable-next-line no-invalid-this
+              expect(this.path).to.equal('/');
+              // eslint-disable-next-line no-invalid-this
+              expect(this).to.be.equal(context.route);
+            })},
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
+        it('onBeforeLeave is called with correct parameters', async() => {
+          const onBeforeLeave = sinon.spy();
+          router.setRoutes([
+            {path: '/', action: onBeforeLeaveAction('x-home-view', onBeforeLeave)},
+            {path: '/users', component: 'x-users-list'},
+          ]);
+
+          await router.render('/');
+          expect(onBeforeLeave).to.not.have.been.called;
+
+          await router.render('/users');
+
+          expect(onBeforeLeave).to.have.been.called.once;
+          expect(onBeforeLeave.args[0].length).to.equal(1);
+          const contextParam = onBeforeLeave.args[0][0];
+          expect(contextParam.pathname).to.equal('/');
+          expect(contextParam.route.path).to.equal('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+        });
+
+        it('onBeforeLeave.this points to the route that defines the component', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeLeaveAction('x-home-view', function(context) {
+              // eslint-disable-next-line no-invalid-this
+              expect(this.path).to.equal('/');
+              // eslint-disable-next-line no-invalid-this
+              expect(this).to.be.equal(context.route);
+            })},
+            {path: '/users', component: 'x-users-list'},
+          ]);
+
+          await router.render('/');
+          await router.render('/users');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+        });
+
+        it('action, onBeforeEnter and onBeforeLeave are called in correct order', async() => {
+          let invocations = [];
+          router.setRoutes([
+            {
+              path: '/',
+              action: context => {
+                const component = context.component('x-home-view');
+                component.onBeforeLeave = () => {
+                  invocations.push('onBeforeLeave');
+                };
+                component.onBeforeEnter = () => {
+                  invocations = [];
+                  invocations.push('onBeforeEnter');
+                };
+                return component;
+              },
+              inactivate: () => {
+                invocations.push('inactivate');
+              }
+            },
+            {path: '/users', component: 'x-users-list', action: () => {
+              invocations.push('action');
+            }},
+          ]);
+
+          await router.render('/');
+          expect(invocations).to.deep.equal(['onBeforeEnter']);
+
+          await router.render('/users');
+          expect(invocations).to.deep.equal(['onBeforeEnter', 'onBeforeLeave', 'action']);
+        });
+
+        it('when onBeforeEnter returns an HTMLElement, the element is rendered and now route is activated', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeEnterAction('whatever', context => context.component('x-users-list'))}
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+          verifyActiveRoutes(router, []);
+        });
+
+        it('when onBeforeLeave returns an HTMLElement, the element is rendered and activation chain is not changed', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.component('x-users-list'))},
+            {path: '/test', component: 'whatever'}
+          ]);
+
+          await router.render('/');
+          await router.render('/test');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+          verifyActiveRoutes(router, []);
+        });
+
+        it('when onBeforeEnter returns a redirect, the redirect target is rendered and activated', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeEnterAction('whatever', context => context.redirect('/users'))},
+            {path: '/users', component: 'x-users-list'}
+          ]);
+
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+          verifyActiveRoutes(router, ['/users']);
+        });
+
+        it('when onBeforeLeave returns a redirect, the redirect target is rendered and activated', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.redirect('/test'))},
+            {path: '/users', component: 'x-users-list'},
+            {path: '/test', component: 'x-image-view'}
+          ]);
+
+          await router.render('/');
+          await router.render('/users');
+
+          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
+          verifyActiveRoutes(router, ['/test']);
+        });
+
+        it('when onBeforeEnter returns cancel and there is no previous state, an error is thrown', async() => {
+          const path = '/';
+          router.setRoutes([
+            {path: path, action: onBeforeEnterAction('whatever', context => context.cancel())},
+          ]);
+
+          let exceptionThrown = false;
+          try {
+            await router.render(path);
+          } catch (e) {
+            expect(e.message).to.contain(path);
+            exceptionThrown = true;
+          }
+          expect(exceptionThrown).to.equal(true);
+        });
+
+        it('when onBeforeEnter returns cancel, resolution is aborted and reverted to the previous state', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeEnterAction('whatever', context => context.cancel())},
+            {path: '/users', component: 'x-users-list'}
+          ]);
+
+          await router.render('/users');
+          await router.render('/');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-list/i);
+          verifyActiveRoutes(router, ['/users']);
+        });
+
+        it('when onBeforeLeave returns cancel, resolution is aborted and reverted to the previous state', async() => {
+          router.setRoutes([
+            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.cancel())},
+            {path: '/users', component: 'x-users-list'},
+          ]);
+
+          await router.render('/');
+          await router.render('/users');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          verifyActiveRoutes(router, []);
+        });
+
+        it('inactivate overrides onBeforeEnter', async() => {
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', inactivate: context => context.cancel(), children: [
+                {path: '/c', component: 'x-home-view'}
+              ]},
+            ]},
+            {path: '/d', action: onBeforeEnterAction('x-users-list', context => context.component('x-image-view'))},
+          ]);
+
+          await router.render('/a/b/c');
+          await router.render('/d');
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          verifyActiveRoutes(router, ['/a', '/b', '/c']);
+        });
+
+        it('inactivate overrides onBeforeEnter for same route but shorter', async() => {
+          const actionToEmulateShorterResolvePass = context => {
+            if ((context.pathname.match(/\//g) || []).length < 2) {
+              const component = context.component('x-home-view');
+              component.onBeforeEnter = context => context.component('x-image-view');
+              return component;
+            }
+          };
+          router.setRoutes([
+            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
+              {path: '/b', component: 'x-users-view', inactivate: context => context.cancel()},
+            ]},
+          ]);
+
+          await router.render('/a/b');
+          await router.render('/a');
+
+          expect(outlet.children[0].tagName).to.match(/x-users-view/i);
+          verifyActiveRoutes(router, ['/a', '/b']);
+        });
+
+        it('onBeforeLeave overrides inactivate', async() => {
+          const inactivate = sinon.spy();
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', inactivate: inactivate, children: [
+                {path: '/c', action: onBeforeLeaveAction('x-home-view', context => context.component('x-image-view'))}
+              ]},
+            ]},
+            {path: '/d', component: 'x-users-list'},
+          ]);
+
+          await router.render('/a/b/c');
+          await router.render('/d');
+
+          expect(inactivate).to.not.have.been.called;
+          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
+          verifyActiveRoutes(router, ['/a', '/b']);
+        });
+
+        it('onBeforeLeave overrides inactivate for same route but shorter', async() => {
+          const inactivate = sinon.spy();
+          const actionToEmulateShorterResolvePass = context => {
+            if ((context.pathname.match(/\//g) || []).length < 2) {
+              return context.component('x-home-view');
+            }
+          };
+          router.setRoutes([
+            {path: '/a', action: actionToEmulateShorterResolvePass, children: [
+              {path: '/b', inactivate: inactivate, action: onBeforeLeaveAction('x-users-view', context => context.component('x-image-view'))},
+            ]},
+          ]);
+
+          await router.render('/a/b');
+          await router.render('/a');
+
+          expect(inactivate).to.not.have.been.called;
+          expect(outlet.children[0].tagName).to.match(/x-image-view/i);
+          verifyActiveRoutes(router, ['/a']);
+        });
+      });
+
+      describe('redirect.from and context.from values for dynamic redirects', () => {
+        let router;
+        beforeEach(() => {
+          router = new Vaadin.Router(outlet);
+        });
+
+        afterEach(() => {
+          router.unsubscribe();
+        });
+
+        const from = '/a/b/c';
+        const redirectFunction = context => {
+          const redirectObject = context.redirect('/d');
+          expect(redirectObject.redirect.from).to.be.equal(from);
+          return redirectObject;
+        };
+        const verificationAction = context => {
+          expect(context.from).to.be.equal(from);
+        };
+
+        it('action with redirect has its context.from and redirect.from populated correctly', async() => {
+          router.setRoutes([
+            {path: '/a', children: [
+              {path: '/b', children: [
+                {path: '/c', action: redirectFunction}
+              ]},
+            ]},
+            {path: '/d', component: 'x-home-view', action: verificationAction}
+          ]);
+
+          await router.render(from);
+
+          expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+        });
+
         it('action with redirect gets double slashes removed from its context.from and redirect.from', async() => {
           let from = '';
           router.setRoutes([
@@ -413,6 +764,22 @@
         });
       });
     });
+
+    function onBeforeLeaveAction(componentName, callback) {
+      return context => {
+        const component = context.component(componentName);
+        component.onBeforeLeave = callback;
+        return component;
+      };
+    }
+
+    function onBeforeEnterAction(componentName, callback) {
+      return context => {
+        const component = context.component(componentName);
+        component.onBeforeEnter = callback;
+        return component;
+      };
+    }
 
     function verifyActiveRoutes(router, expectedSegments) {
       expect(router.__previousContext.chain.map(route => route.path)).to.deep.equal(expectedSegments);

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -1,0 +1,254 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>Vaadin.Router Livecycle Events spec</title>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../dist/vaadin-router.umd.js"></script>
+
+  <link rel="import" href="../test-pushstate-throttler.html">
+</head>
+
+<body>
+  <test-pushstate-throttler id="throttler"></test-pushstate-throttler>
+  <div id="outlet"></div>
+
+  <script>
+    const invocations = [];
+    class XSpyComponent extends HTMLElement {
+      constructor() {
+        super();
+      }
+      connectedCallback() {
+        this.log('connectedCallback')
+      }
+      disconnectedCallback() {
+        this.log('disconnectedCallback')
+      }
+      onBeforeEnter() {
+        this.log('onBeforeEnter')
+      }
+      onAfterEnter() {
+        this.log('onAfterEnter')
+      }
+      onBeforeLeave() {
+        this.log('onBeforeLeave')
+      }
+      onAfterLeave() {
+        this.log('onAfterLeave')
+      }
+
+      log(message) {
+        invocations.push(`${this.name}.${message}`);
+      }
+    }
+    customElements.define('x-spy-component', XSpyComponent);
+
+    function spyComponent(name) {
+      return (context) => {
+        invocations.push(`${name}.action`);
+        const component = context.component('x-spy-component');
+        component.name = name;
+        return component;
+      }
+    }
+
+    describe('Vaadin.Router lifecycle events', function() {
+      // eslint-disable-next-line no-invalid-this
+      const suite = this;
+      suite.title = suite.title + (window.ShadyDOM ? ' (Shady DOM)' : '');
+
+      const outlet = document.getElementById('outlet');
+      const throttler = document.getElementById('throttler');
+      let router;
+      beforeEach(async function() {
+        // eslint-disable-next-line no-invalid-this
+        const test = this;
+
+        // if necessary wait before it's OK to call history.pushState again
+        await throttler.throttle(test);
+
+        // reset the window URL
+        window.history.pushState(null, null, '/');
+
+        // create a new router instance
+        router = new Vaadin.Router(outlet);
+      });
+
+      afterEach(() => {
+        router.unsubscribe();
+      });
+
+      describe('lifecycle events order: no early returns', () => {
+        it('(initial) -> /a', async() => {
+          router.setRoutes([
+            {path: '/a', action: spyComponent('a')},
+          ]);
+
+          await router.render('/').catch(() => {});
+          invocations.length = 0;
+          await router.render('/a');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            'a.onBeforeEnter',
+            'a.connectedCallback',
+            'a.onAfterEnter',
+          ]);
+        });
+
+        it('/a -> /b', async() => {
+          router.setRoutes([
+            {path: '/a', action: spyComponent('a')},
+            {path: '/b', action: spyComponent('b')},
+          ]);
+
+          await router.render('/a');
+          invocations.length = 0;
+          await router.render('/b');
+
+          expect(invocations).to.deep.equal([
+            'a.onBeforeLeave',
+            'b.action',
+            'b.onBeforeEnter',
+            'b.connectedCallback',
+            'b.onAfterEnter',
+            'a.disconnectedCallback',
+          ]);
+        });
+
+        it('(initial) -> /a/b', async() => {
+          router.setRoutes([
+            {
+              path: '/a',
+              action: () => { invocations.push('a.action') },
+              children: [
+                {path: '/b', action: spyComponent('b')},
+              ]
+            },
+          ]);
+
+          await router.render('/').catch(() => {});
+          invocations.length = 0;
+          await router.render('/a/b');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            'b.action',
+            'b.onBeforeEnter',
+            'b.connectedCallback',
+            'b.onAfterEnter',
+          ]);
+        });
+
+        it('/a/b -> /a/c', async() => {
+          router.setRoutes([
+            {
+              path: '/a',
+              action: () => { invocations.push('a.action') },
+              children: [
+                {path: '/b', action: spyComponent('b')},
+                {path: '/c', action: spyComponent('c')},
+              ]
+            },
+          ]);
+
+          await router.render('/a/b');
+          invocations.length = 0;
+          await router.render('/a/c');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            'b.onBeforeLeave',
+            'c.action',
+            'c.onBeforeEnter',
+            'c.connectedCallback',
+            'c.onAfterEnter',
+            'b.disconnectedCallback',
+          ]);
+        });
+
+        it('(initial) -> /a/non-existent-path', async() => {
+          router.setRoutes([
+            {
+              path: '/a',
+              action: () => { invocations.push('a.action') },
+              children: [
+                {path: '/b', action: spyComponent('b')},
+              ]
+            },
+            {path: '(.*)', action: spyComponent('*')},
+          ]);
+
+          await router.render('/').catch(() => {});
+          invocations.length = 0;
+          await router.render('/a/non-existent-path');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            '*.action',
+            '*.onBeforeEnter',
+            '*.connectedCallback',
+            '*.onAfterEnter',
+          ]);
+        });
+
+        it('/a/b -> /a/non-existent-path', async() => {
+          router.setRoutes([
+            {
+              path: '/a',
+              action: () => { invocations.push('a.action') },
+              children: [
+                {path: '/b', action: spyComponent('b')},
+              ]
+            },
+            {path: '(.*)', action: spyComponent('*')},
+          ]);
+
+          await router.render('/a/b');
+          invocations.length = 0;
+          await router.render('/a/non-existent-path');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            'b.onBeforeLeave',
+            '*.action',
+            '*.onBeforeEnter',
+            '*.connectedCallback',
+            '*.onAfterEnter',
+            'b.disconnectedCallback',
+          ]);
+        });
+
+        it('/a/c -> /a/d (/a gets visited, but does not get matched)', async() => {
+          router.setRoutes([
+            {
+              path: '/a',
+              action: () => { invocations.push('a.action') },
+              children: [
+                {path: '/b', action: spyComponent('b')},
+              ]
+            },
+            {path: '/a/c', action: spyComponent('ac')},
+            {path: '/a/d', action: spyComponent('ad')},
+          ]);
+
+          await router.render('/a/c');
+          invocations.length = 0;
+          await router.render('/a/d');
+
+          expect(invocations).to.deep.equal([
+            'a.action',
+            'ac.onBeforeLeave',
+            'ad.action',
+            'ad.onBeforeEnter',
+            'ad.connectedCallback',
+            'ad.onAfterEnter',
+            'ac.disconnectedCallback',
+          ]);
+        });
+      });
+    });
+  </script>
+</body>

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -174,7 +174,7 @@
           router.setRoutes([
             {
               path: '/a',
-              action: onBeforeEnterAction('x-spy', function (context) {
+              action: onBeforeEnterAction('x-spy', function() {
                 // eslint-disable-next-line no-invalid-this
                 const self = this;
                 self.log('onBeforeEnter');
@@ -294,7 +294,7 @@
           router.setRoutes([
             {
               path: '/a',
-              action: onBeforeLeaveAction('x-spy', function (context) {
+              action: onBeforeLeaveAction('x-spy', function() {
                 // eslint-disable-next-line no-invalid-this
                 const self = this;
                 self.log('onBeforeLeave');
@@ -396,21 +396,18 @@
 
         it('should support returning a promise (and continue the resolve pass after the promise resolves)', async() => {
           router.setRoutes([
-            {
-              path: '/a',
-              action: onAfterEnterAction('x-spy', function (context) {
-                // eslint-disable-next-line no-invalid-this
-                const self = this;
-                self.log('onAfterEnter');
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    self.log('onAfterEnter.promise');
-                    resolve();
-                  }, 100);
-                });
-              })
-            },
-            {path: '/b', component: 'x-spy'},
+            {path: '/a', component: 'x-spy'},
+            {path: '/b', action: onAfterEnterAction('x-spy', function() {
+              // eslint-disable-next-line no-invalid-this
+              const self = this;
+              self.log('onAfterEnter');
+              return new Promise(resolve => {
+                setTimeout(() => {
+                  self.log('onAfterEnter.promise');
+                  resolve(22);
+                }, 100);
+              });
+            })},
           ]);
 
           await router.render('/').catch(() => {});
@@ -422,7 +419,6 @@
             outlet.children[0].name = 'b';
           });
 
-          console.table(XSpy.getLog());
           expect(XSpy.getLog()).to.deep.equal([
             'a.onBeforeLeave',
             'b.onBeforeEnter',

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -21,22 +21,22 @@
         this.name = `x-spy#${XSpy.__instanceCount++}`;
       }
       connectedCallback() {
-        this.log('connectedCallback')
+        this.log('connectedCallback');
       }
       disconnectedCallback() {
-        this.log('disconnectedCallback')
+        this.log('disconnectedCallback');
       }
       onBeforeEnter() {
-        this.log('onBeforeEnter')
+        this.log('onBeforeEnter');
       }
       onAfterEnter() {
-        this.log('onAfterEnter')
+        this.log('onAfterEnter');
       }
       onBeforeLeave() {
-        this.log('onBeforeLeave')
+        this.log('onBeforeLeave');
       }
       onAfterLeave() {
-        this.log('onAfterLeave')
+        this.log('onAfterLeave');
       }
 
       log(message) {
@@ -49,13 +49,13 @@
     XSpy.__log = [];
     XSpy.log = (message) => {
       XSpy.__log.push(message);
-    }
+    };
     XSpy.getLog = () => {
       return XSpy.__log.map(entry => `${typeof entry === 'function' ? entry() : entry}`);
-    }
+    };
     XSpy.clearLog = () => {
       XSpy.__log.length = [];
-    }
+    };
 
     describe('Vaadin.Router lifecycle events', function() {
       // eslint-disable-next-line no-invalid-this
@@ -91,7 +91,9 @@
 
           await router.render('/').catch(() => {});
           XSpy.clearLog();
-          await router.render('/a').then(outlet => { outlet.children[0].name = 'a' });
+          await router.render('/a').then(outlet => {
+            outlet.children[0].name = 'a';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
             'a.action',
@@ -107,17 +109,21 @@
             {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a').then(outlet => { outlet.children[0].name = 'a' });
+          await router.render('/a').then(outlet => {
+            outlet.children[0].name = 'a';
+          });
           XSpy.clearLog();
-          await router.render('/b').then(outlet => { outlet.children[0].name = 'b' });
+          await router.render('/b').then(outlet => {
+            outlet.children[0].name = 'b';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
-            'a.onBeforeLeave',
             'b.action',
+            'a.onBeforeLeave',
             'b.onBeforeEnter',
+            'a.disconnectedCallback',
             'b.connectedCallback',
             'b.onAfterEnter',
-            'a.disconnectedCallback',
           ]);
         });
 
@@ -134,7 +140,9 @@
 
           await router.render('/').catch(() => {});
           XSpy.clearLog();
-          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
+          await router.render('/a/b').then(outlet => {
+            outlet.children[0].name = 'b';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
             'a.action',
@@ -157,18 +165,22 @@
             },
           ]);
 
-          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
+          await router.render('/a/b').then(outlet => {
+            outlet.children[0].name = 'b';
+          });
           XSpy.clearLog();
-          await router.render('/a/c').then(outlet => { outlet.children[0].name = 'c' });
+          await router.render('/a/c').then(outlet => {
+            outlet.children[0].name = 'c';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
             'a.action',
-            'b.onBeforeLeave',
             'c.action',
+            'b.onBeforeLeave',
             'c.onBeforeEnter',
+            'b.disconnectedCallback',
             'c.connectedCallback',
             'c.onAfterEnter',
-            'b.disconnectedCallback',
           ]);
         });
 
@@ -186,15 +198,11 @@
 
           await router.render('/').catch(() => {});
           XSpy.clearLog();
-          await router.render('/a/non-existent-path').then(outlet => { outlet.children[0].name = '*' });
+          await router.render('/a/non-existent-path').then(outlet => {
+            outlet.children[0].name = '*';
+          });
 
-          expect(XSpy.getLog()).to.deep.equal([
-            'a.action',
-            '*.action',
-            '*.onBeforeEnter',
-            '*.connectedCallback',
-            '*.onAfterEnter',
-          ]);
+          expect(XSpy.getLog()).to.deep.equal(['a.action', '*.action']);
         });
 
         it('/a/b -> /a/non-existent-path', async() => {
@@ -209,18 +217,22 @@
             {path: '(.*)', action: () => XSpy.log('*.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
+          await router.render('/a/b').then(outlet => {
+            outlet.children[0].name = 'b';
+          });
           XSpy.clearLog();
-          await router.render('/a/non-existent-path').then(outlet => { outlet.children[0].name = '*' });
+          await router.render('/a/non-existent-path').then(outlet => {
+            outlet.children[0].name = '*';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
             'a.action',
-            'b.onBeforeLeave',
             '*.action',
+            'b.onBeforeLeave',
             '*.onBeforeEnter',
+            'b.disconnectedCallback',
             '*.connectedCallback',
             '*.onAfterEnter',
-            'b.disconnectedCallback',
           ]);
         });
 
@@ -237,19 +249,37 @@
             {path: '/a/d', action: () => XSpy.log('ad.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a/c').then(outlet => { outlet.children[0].name = 'ac' });
+          await router.render('/a/c').then(outlet => {
+            outlet.children[0].name = 'ac';
+          });
           XSpy.clearLog();
-          await router.render('/a/d').then(outlet => { outlet.children[0].name = 'ad' });
+          await router.render('/a/d').then(outlet => {
+            outlet.children[0].name = 'ad';
+          });
 
           expect(XSpy.getLog()).to.deep.equal([
             'a.action',
-            'ac.onBeforeLeave',
             'ad.action',
+            'ac.onBeforeLeave',
             'ad.onBeforeEnter',
+            'ac.disconnectedCallback',
             'ad.connectedCallback',
             'ad.onAfterEnter',
-            'ac.disconnectedCallback',
           ]);
+        });
+
+        it('/users/Jane -> /users/John (when parameters are changed, no extra callbacks are called)', async() => {
+          router.setRoutes([
+            {path: '/users/:user', action: () => XSpy.log('route.action'), component: 'x-spy'},
+          ]);
+
+          await router.render('/users/Jane');
+          XSpy.clearLog();
+          await router.render('/users/John').then(outlet => {
+            outlet.children[0].name = 'john';
+          });
+
+          expect(XSpy.getLog()).to.deep.equal(['route.action']);
         });
       });
     });

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -15,10 +15,10 @@
   <div id="outlet"></div>
 
   <script>
-    const invocations = [];
-    class XSpyComponent extends HTMLElement {
+    class XSpy extends HTMLElement {
       constructor() {
         super();
+        this.name = `x-spy#${XSpy.__instanceCount++}`;
       }
       connectedCallback() {
         this.log('connectedCallback')
@@ -40,18 +40,21 @@
       }
 
       log(message) {
-        invocations.push(`${this.name}.${message}`);
+        XSpy.log(() => `${this.name}.${message}`);
       }
     }
-    customElements.define('x-spy-component', XSpyComponent);
+    customElements.define('x-spy', XSpy);
 
-    function spyComponent(name) {
-      return (context) => {
-        invocations.push(`${name}.action`);
-        const component = context.component('x-spy-component');
-        component.name = name;
-        return component;
-      }
+    XSpy.__instanceCount = 0;
+    XSpy.__log = [];
+    XSpy.log = (message) => {
+      XSpy.__log.push(message);
+    }
+    XSpy.getLog = () => {
+      return XSpy.__log.map(entry => `${typeof entry === 'function' ? entry() : entry}`);
+    }
+    XSpy.clearLog = () => {
+      XSpy.__log.length = [];
     }
 
     describe('Vaadin.Router lifecycle events', function() {
@@ -83,14 +86,14 @@
       describe('lifecycle events order: no early returns', () => {
         it('(initial) -> /a', async() => {
           router.setRoutes([
-            {path: '/a', action: spyComponent('a')},
+            {path: '/a', action: () => XSpy.log('a.action'), component: 'x-spy'},
           ]);
 
           await router.render('/').catch(() => {});
-          invocations.length = 0;
-          await router.render('/a');
+          XSpy.clearLog();
+          await router.render('/a').then(outlet => { outlet.children[0].name = 'a' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             'a.onBeforeEnter',
             'a.connectedCallback',
@@ -100,15 +103,15 @@
 
         it('/a -> /b', async() => {
           router.setRoutes([
-            {path: '/a', action: spyComponent('a')},
-            {path: '/b', action: spyComponent('b')},
+            {path: '/a', action: () => XSpy.log('a.action'), component: 'x-spy'},
+            {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a');
-          invocations.length = 0;
-          await router.render('/b');
+          await router.render('/a').then(outlet => { outlet.children[0].name = 'a' });
+          XSpy.clearLog();
+          await router.render('/b').then(outlet => { outlet.children[0].name = 'b' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.onBeforeLeave',
             'b.action',
             'b.onBeforeEnter',
@@ -122,18 +125,18 @@
           router.setRoutes([
             {
               path: '/a',
-              action: () => { invocations.push('a.action') },
+              action: () => XSpy.log('a.action'),
               children: [
-                {path: '/b', action: spyComponent('b')},
+                {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
               ]
             },
           ]);
 
           await router.render('/').catch(() => {});
-          invocations.length = 0;
-          await router.render('/a/b');
+          XSpy.clearLog();
+          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             'b.action',
             'b.onBeforeEnter',
@@ -146,19 +149,19 @@
           router.setRoutes([
             {
               path: '/a',
-              action: () => { invocations.push('a.action') },
+              action: () => XSpy.log('a.action'),
               children: [
-                {path: '/b', action: spyComponent('b')},
-                {path: '/c', action: spyComponent('c')},
+                {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
+                {path: '/c', action: () => XSpy.log('c.action'), component: 'x-spy'},
               ]
             },
           ]);
 
-          await router.render('/a/b');
-          invocations.length = 0;
-          await router.render('/a/c');
+          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
+          XSpy.clearLog();
+          await router.render('/a/c').then(outlet => { outlet.children[0].name = 'c' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             'b.onBeforeLeave',
             'c.action',
@@ -173,19 +176,19 @@
           router.setRoutes([
             {
               path: '/a',
-              action: () => { invocations.push('a.action') },
+              action: () => XSpy.log('a.action'),
               children: [
-                {path: '/b', action: spyComponent('b')},
+                {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
               ]
             },
-            {path: '(.*)', action: spyComponent('*')},
+            {path: '(.*)', action: () => XSpy.log('*.action'), component: 'x-spy'},
           ]);
 
           await router.render('/').catch(() => {});
-          invocations.length = 0;
-          await router.render('/a/non-existent-path');
+          XSpy.clearLog();
+          await router.render('/a/non-existent-path').then(outlet => { outlet.children[0].name = '*' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             '*.action',
             '*.onBeforeEnter',
@@ -198,19 +201,19 @@
           router.setRoutes([
             {
               path: '/a',
-              action: () => { invocations.push('a.action') },
+              action: () => XSpy.log('a.action'),
               children: [
-                {path: '/b', action: spyComponent('b')},
+                {path: '/b', action: () => XSpy.log('b.action'), component: 'x-spy'},
               ]
             },
-            {path: '(.*)', action: spyComponent('*')},
+            {path: '(.*)', action: () => XSpy.log('*.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a/b');
-          invocations.length = 0;
-          await router.render('/a/non-existent-path');
+          await router.render('/a/b').then(outlet => { outlet.children[0].name = 'b' });
+          XSpy.clearLog();
+          await router.render('/a/non-existent-path').then(outlet => { outlet.children[0].name = '*' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             'b.onBeforeLeave',
             '*.action',
@@ -225,20 +228,20 @@
           router.setRoutes([
             {
               path: '/a',
-              action: () => { invocations.push('a.action') },
+              action: () => XSpy.log('a.action'),
               children: [
-                {path: '/b', action: spyComponent('b')},
+                {path: '/b', action: () => XSpy.log('a.action'), component: 'x-spy'},
               ]
             },
-            {path: '/a/c', action: spyComponent('ac')},
-            {path: '/a/d', action: spyComponent('ad')},
+            {path: '/a/c', action: () => XSpy.log('ac.action'), component: 'x-spy'},
+            {path: '/a/d', action: () => XSpy.log('ad.action'), component: 'x-spy'},
           ]);
 
-          await router.render('/a/c');
-          invocations.length = 0;
-          await router.render('/a/d');
+          await router.render('/a/c').then(outlet => { outlet.children[0].name = 'ac' });
+          XSpy.clearLog();
+          await router.render('/a/d').then(outlet => { outlet.children[0].name = 'ad' });
 
-          expect(invocations).to.deep.equal([
+          expect(XSpy.getLog()).to.deep.equal([
             'a.action',
             'ac.onBeforeLeave',
             'ad.action',

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -404,7 +404,7 @@
               return new Promise(resolve => {
                 setTimeout(() => {
                   self.log('onAfterEnter.promise');
-                  resolve(22);
+                  resolve();
                 }, 100);
               });
             })},

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -583,6 +583,9 @@
             expect(contextParam.pathname).to.equal('/');
             expect(contextParam.route.path).to.equal('/');
             expect(contextParam.route.component).to.equal('x-home-view');
+            expect(contextParam.cancel).to.be.an('undefined');
+            expect(contextParam.redirect).to.be.a('function');
+            expect(contextParam.component).to.be.a('function');
           });
 
           it('action.this points to the route that defines action', async() => {
@@ -751,16 +754,6 @@
             expect(elem.route.params.id).to.equal('1');
           });
 
-          it('context.cancel() return value is ignored for action', async() => {
-            router.setRoutes([
-              {path: '/', action: context => context.cancel(), component: 'x-home-view'}
-            ]);
-
-            await router.render('/');
-
-            expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          });
-
           it('redirect should be executed before bundle and stop it from loading', async() => {
             router.setRoutes([
               {path: '/test', redirect: '/users', component: 'x-home-view'},
@@ -781,6 +774,48 @@
             await router.render('/a');
 
             expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          });
+
+          it('action with redirect has its context.from and redirect.from populated correctly', async() => {
+            const from = '/a/b/c';
+
+            router.setRoutes([
+              {path: '/a', children: [
+                {path: '/b', children: [
+                  {path: '/c', action: context => {
+                    const redirectObject = context.redirect('/d');
+                    expect(redirectObject.redirect.from).to.be.equal(from);
+                    return redirectObject;
+                  }}
+                ]},
+              ]},
+              {path: '/d', component: 'x-home-view', action: context => {
+                expect(context.from).to.be.equal(from);
+              }}
+            ]);
+
+            await router.render(from);
+
+            expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+          });
+
+          it('action with redirect gets double slashes removed from its context.from and redirect.from', async() => {
+            let from = '';
+            router.setRoutes([
+              {path: '/', children: [
+                {path: '', children: [
+                  {path: '/c', action: context => context.redirect('/d')}
+                ]},
+              ]},
+              {path: '/d', component: 'x-home-view', action: context => {
+                from = context.from;
+              }}
+            ]);
+
+            await router.render('/c');
+
+            expect(outlet.children[0].tagName).to.match(/x-home-view/i);
+            expect(from).to.be.equal('/c');
           });
         });
       });

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -3,6 +3,7 @@ window.VaadinRouterSuites = {
     'resolver/resolver.spec.js',
     'router/router.spec.html',
     'router/dynamic.redirect.spec.html',
+    'router/lifecycle-events.spec.html',
   ],
   coverage: [
     'resolver/matchPath.spec.js',


### PR DESCRIPTION
Closes #23 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/151)
<!-- Reviewable:end -->
