### PR TITLE
add npm install snippet to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ branches:
    - master
 
 script:
+  - yarn install:dependencies
+  - yarn build
   - yarn lint
   - if [[ $TRAVIS_PULL_REQUEST == "false" && "$TRAVIS_BRANCH" == "master" ]]; then
       wct --env saucelabs;

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Vaadin.Router is a small yet powerfull client-side router JS library. It uses th
 
 Vaadin.Router is a good fit for developers that do not want to go all-in with one framework, and prefer to have freedom in picking the components that work best for their specific needs.
 
+```
+npm install --save @vaadin/router
+```
+
 ```javascript
 import {Router} from '@vaadin/router';
 
@@ -39,7 +43,7 @@ Testing environments for Vaadin.Router are provided by [SauceLabs](https://sauce
 
 1. Make sure you have [npm](https://www.npmjs.com/) installed.
 
-1. When in the `vaadin-router` directory, run `npm install` to install dependencies.
+1. When in the `vaadin-router` directory, run `npm install` and then `npm run install:dependencies` to install dependencies.
 
 1. Run `npm start`, and open [http://127.0.0.1:8000/components/vaadin-router](http://127.0.0.1:8000/components/vaadin-router) in your browser to see the component API documentation.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/router",
-  "version": "1.0.0-alpha.0",
+  "version": "0.1.0",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.umd.js",
   "browser": "dist/vaadin-router.mjs",
@@ -18,6 +18,11 @@
     "url": "https://github.com/vaadin/vaadin-router/issues"
   },
   "homepage": "https://vaadin.com",
+  "files": [
+    "index.js",
+    "src",
+    "dist/vaadin-router.*"
+  ],
   "scripts": {
     "install": "bower install && npm run build",
     "lint": "npm-run-all --parallel lint:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/router",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.umd.js",
   "browser": "dist/vaadin-router.mjs",
@@ -24,7 +24,7 @@
     "dist/vaadin-router.*"
   ],
   "scripts": {
-    "install": "bower install && npm run build",
+    "install:dependencies": "bower install",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "eslint --ext .html,.js src test demo *.js *.html",
     "lint:css": "stylelint demo/**/*.html",
@@ -32,7 +32,7 @@
     "build:minify.module": "uglifyjs dist/vaadin-router.umd.js -c -m --mangle-props regex=/^__/ --source-map --output dist/vaadin-router.umd.min.js",
     "build:minify.browser": "uglifyjs dist/vaadin-router.mjs -c -m --mangle-props regex=/^__/ --toplevel --source-map --output dist/vaadin-router.min.mjs",
     "build:watch": "rollup -c -w",
-    "start": "polyserve --port 8000",
+    "start": "npm run build && polyserve --port 8000",
     "start:browser-sync": "browser-sync start --config bs-config.js",
     "start:watch": "npm-run-all --parallel build:watch start start:browser-sync",
     "test": "wct && npm run test:coverage",


### PR DESCRIPTION
 - use SemVer (start with 0.1.0)
 -  remove the npm postinstall script
    it works find when running `npm install` after cloning the repo, but breaks when trying to install `@vaadin/router` as a dependency in another project with `npm install @vaadin/router`
 -  add an npm install snippet to README

closes #34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/155)
<!-- Reviewable:end -->
