### PR TITLE
Restore using .js extension for better tools compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.umd.js",
-  "browser": "dist/vaadin-router.mjs",
+  "browser": "dist/vaadin-router.js",
   "repository": "vaadin/vaadin-router",
   "keywords": [
     "Vaadin",
@@ -30,7 +30,7 @@
     "lint:css": "stylelint demo/**/*.html",
     "build": "rollup -c && npm-run-all --parallel build:minify.*",
     "build:minify.module": "uglifyjs dist/vaadin-router.umd.js -c -m --mangle-props regex=/^__/ --source-map --output dist/vaadin-router.umd.min.js",
-    "build:minify.browser": "uglifyjs dist/vaadin-router.mjs -c -m --mangle-props regex=/^__/ --toplevel --source-map --output dist/vaadin-router.min.mjs",
+    "build:minify.browser": "uglifyjs dist/vaadin-router.js -c -m --mangle-props regex=/^__/ --toplevel --source-map --output dist/vaadin-router.min.js",
     "build:watch": "rollup -c -w",
     "start": "npm run build && polyserve --port 8000",
     "start:browser-sync": "browser-sync start --config bs-config.js",
@@ -44,7 +44,7 @@
   },
   "bundlesize": [
     {
-      "path": "dist/vaadin-router.min.mjs",
+      "path": "dist/vaadin-router.min.js",
       "maxSize": "6 kB"
     }
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,19 +42,6 @@ const config = [
     plugins
   },
 
-  // ES module bundle, not transpiled (for the API docs generation)
-  // FIXME: remove once polymer-cli adds `.mjs` file extension support
-  // See https://github.com/Polymer/tools/issues/415
-  {
-    input: 'index.js',
-    output: {
-      format: 'es',
-      file: pkg.browser.replace('.mjs', '.js'),
-      sourcemap: true,
-    },
-    plugins
-  },
-
   // UMD bundle, transpiled (for the browsers that do not support ES modules).
   // Also works in Node.
   {


### PR DESCRIPTION
Fixes #156 

Let's not use `.mjs` while it is considered to be more a node-specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/157)
<!-- Reviewable:end -->
