### PR TITLE
add a dynamic redirect demo (from onBeforeEnter)

### DIFF
--- a/demo/vaadin-router-redirect-demos.html
+++ b/demo/vaadin-router-redirect-demos.html
@@ -66,6 +66,70 @@
         </script>
       </template>
     </vaadin-demo-snippet>
+
+    <h3>Dynamic Redirects</h3>
+    <p>
+      Vaadin.Router allows redirecting to another route dynamically based on
+      a condition evaluated at the run time. In order to do that, add <code>
+      return context.redirect('/new/path')</code> into the <code>onBeforeEnter()
+      </code> lifecycle callback of the route Web Component.
+    </p>
+    <p>
+      It is also possible to redirect from a custom route action. The demo below
+      has an example of that in the <code>/logout</code> route action. See the
+      <a href="#vaadin-router-route-actions-demos">Route Actions</a> section for
+      more details.
+    </p>
+    <vaadin-demo-snippet id="vaadin-router-redirect-demos-2" iframe-src="iframe.html">
+      <template preserve-content>
+        <a href="/">Home</a>
+        <a href="/admin">Admin</a>
+        <a href="/login">Login</a>
+        <a href="/logout">Logout</a>
+        <div id="outlet"></div>
+        <script type="module">
+          let authorized = false;
+          customElements.define('x-admin-view', class extends HTMLElement {
+            onBeforeEnter(context) {
+              if (!authorized) {
+                return context.redirect('/login/' + encodeURIComponent(context.pathname));
+              }
+            }
+
+            connectedCallback() {
+              const root = this.shadowRoot || this.attachShadow({mode: 'open'});
+              root.innerHTML = 'Secret admin stuff';
+            }
+          });
+
+          customElements.define('x-login-view', class extends HTMLElement {
+            connectedCallback() {
+              const root = this.shadowRoot || this.attachShadow({mode: 'open'});
+              root.innerHTML =
+                '<h1>Login Form</h1>' +
+                '<button id="login">Login with OAuth</button>';
+              root.querySelector('#login').addEventListener('click', () => {
+                authorized = true;
+                router.render(this.route.params.to || '/', true);
+              });
+            }
+          });
+
+          const {Router} = window.Vaadin;
+
+          const router = new Router(document.getElementById('outlet'));
+          router.setRoutes([
+            {path: '/', component: 'x-home-view'},
+            {path: '/admin', component: 'x-admin-view'},
+            {path: '/login/:to?', component: 'x-login-view'},
+            {path: '/logout', action: (context) => {
+              authorized = false;
+              return context.redirect('/');
+            }},
+          ]);
+        </script>
+      </template>
+    </vaadin-demo-snippet>
   </template>
   <script>
     class VaadinRouterRedirectDemos extends DemoReadyEventEmitter(ElementDemo(Polymer.Element)) {


### PR DESCRIPTION
The same demo shows how to redirect from the `onBeforeEnter` lifecycle callback (see the `x-admin-view` custom element) and from a custom route action (see the `/logout` route).

Closes #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/159)
<!-- Reviewable:end -->
