### PR TITLE
disable property names mangling in UMD builds

### DIFF
--- a/demo/vaadin-router-getting-started-demos.html
+++ b/demo/vaadin-router-getting-started-demos.html
@@ -25,7 +25,7 @@
       <code>Router</code> class is exposed as a member of the <code>Vaadin</code>
       namespace after the vaadin-router UMD bundle is loaded:
     </p>
-    <pre><code>&lt;script src="https://unpkg.com/@vaadin/router/dist/vaadin-router.umd.js"&gt;&lt;/script&gt;
+    <pre><code>&lt;script src="https://unpkg.com/@vaadin/router/dist/vaadin-router.umd.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
   var Router = Vaadin.Router;
 &lt;/script&gt;</code></pre>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:js": "eslint --ext .html,.js src test demo *.js *.html",
     "lint:css": "stylelint demo/**/*.html",
     "build": "rollup -c && npm-run-all --parallel build:minify.*",
-    "build:minify.module": "uglifyjs dist/vaadin-router.umd.js -c -m --mangle-props regex=/^__/ --source-map --output dist/vaadin-router.umd.min.js",
+    "build:minify.module": "uglifyjs dist/vaadin-router.umd.js -c -m --source-map --output dist/vaadin-router.umd.min.js",
     "build:minify.browser": "uglifyjs dist/vaadin-router.js -c -m --mangle-props regex=/^__/ --toplevel --source-map --output dist/vaadin-router.min.js",
     "build:watch": "rollup -c -w",
     "start": "npm run build && polyserve --port 8000",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaadin/router",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.umd.js",
   "browser": "dist/vaadin-router.js",

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
   <script src="../bower_components/web-component-tester/browser.js"></script>
   <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <script src="test-suites.js"></script>
-  <script src="../dist/vaadin-router.umd.js"></script>
+  <script src="../dist/vaadin-router.umd.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
(since it does not work with the babel transform-es2015-classes plugin)

feature request in babel/minify: https://github.com/babel/minify/issues/358
bump the version to 0.2.1

Fixes: #160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/165)
<!-- Reviewable:end -->
