### PR TITLE
add an informative error message when router is used unconfigured

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -236,7 +236,6 @@ export class Router extends Resolver {
    * @return {!Promise<!Node>}
    */
   render(pathnameOrContext, shouldUpdateHistory) {
-    this.__ensureOutlet();
     const renderId = ++this.__lastStartedRenderId;
     this.ready = this.resolve(pathnameOrContext)
       .then(originalContext => this.__fullyResolveChain(originalContext, originalContext))
@@ -448,7 +447,7 @@ export class Router extends Resolver {
   }
 
   __removeOutletContent(content) {
-    content = content || this.__outlet.children;
+    content = content || (this.__outlet && this.__outlet.children);
     if (content && content.length) {
       const parent = content[0].parentNode;
       for (let i = 0; i < content.length; i += 1) {
@@ -521,9 +520,7 @@ export class Router extends Resolver {
 
   __onNavigationEvent(event) {
     const pathname = event ? event.detail.pathname : window.location.pathname;
-    if (this.root.children.length > 0) {
-      this.render(pathname, true);
-    }
+    this.render(pathname, true);
   }
 
   /**

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -84,6 +84,34 @@
             const router = new Vaadin.Router(null, {baseUrl: '/users'});
             expect(router).to.have.property('baseUrl', '/users');
           });
+
+          it('should not fail silently if not configured (both routes and outlet missing)', async() => {
+            const router = new Vaadin.Router();
+            const onError = sinon.spy();
+            const link = document.getElementById('admin-anchor');
+            link.click();
+            await router.ready.catch(onError);
+
+            expect(onError).to.have.been.called.once;
+
+            const error = onError.args[0][0];
+            expect(error).to.be.an('error');
+            expect(error.message).to.match(/page not found/i);
+          });
+
+          it('should not fail silently if not configured (outlet is set but routes are missing)', async() => {
+            const router = new Vaadin.Router(outlet);
+            const onError = sinon.spy();
+            const link = document.getElementById('admin-anchor');
+            link.click();
+            await router.ready.catch(onError);
+
+            expect(onError).to.have.been.called.once;
+
+            const error = onError.args[0][0];
+            expect(error).to.be.an('error');
+            expect(error.message).to.match(/page not found/i);
+          });
         });
 
         describe('router.render(pathname)', () => {
@@ -100,20 +128,6 @@
 
           afterEach(() => {
             router.unsubscribe();
-          });
-
-          it('should throw if the router outlet is not a valid DOM Node (on start)', () => {
-            [
-              undefined,
-              null,
-              0,
-              false,
-              '',
-              NaN
-            ].forEach(invalidOutlet => {
-              router.setOutlet(invalidOutlet);
-              expect(() => router.render('/'), `${invalidOutlet}`).to.throw(TypeError);
-            });
           });
 
           it('should throw if the router outlet is a not valid DOM Node (on finish)', async() => {
@@ -436,17 +450,6 @@
             await router.ready;
             expect(outlet.children).to.have.lengthOf(1);
             expect(outlet.children[0].tagName).to.match(/x-home-view/i);
-          });
-
-          it('should ignore navigation events if no routes are set', async() => {
-            router.setRoutes([]);
-            await router.ready;
-
-            window.dispatchEvent(new CustomEvent('vaadin-router:go', {detail: {pathname: '/'}}));
-            const fulfilled = sinon.spy();
-            const rejected = sinon.spy();
-            await router.ready.then(fulfilled).catch(rejected);
-            expect(rejected).to.not.have.been.called;
           });
 
           it('should use the POPSTATE navigation trigger by default', async() => {


### PR DESCRIPTION
Fixes #183 

Instead of silently skipping navigation if no routes are configured, proceed with navigation and handle misconfiguration as any other router issue, i.e. log an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/184)
<!-- Reviewable:end -->
