### PR TITLE
Use history.replaceState when redirecting

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -243,7 +243,7 @@ export class Router extends Resolver {
       .then(context => {
         if (renderId === this.__lastStartedRenderId) {
           if (shouldUpdateHistory) {
-            this.__updateBrowserHistory(context.result.route.pathname);
+            this.__updateBrowserHistory(context.result.route.pathname, context.from);
           }
 
           if (context !== this.__previousContext) {
@@ -379,10 +379,11 @@ export class Router extends Resolver {
     }
   }
 
-  __updateBrowserHistory(pathnameOrContext) {
+  __updateBrowserHistory(pathnameOrContext, replace) {
     const pathname = pathnameOrContext.pathname || pathnameOrContext;
     if (window.location.pathname !== pathname) {
-      window.history.pushState(null, document.title, pathname);
+      const changeState = replace ? 'replaceState' : 'pushState';
+      window.history[changeState](null, document.title, pathname);
       window.dispatchEvent(new PopStateEvent('popstate', {state: 'vaadin-router:ignore'}));
     }
   }

--- a/test/router/dynamic-redirect.spec.html
+++ b/test/router/dynamic-redirect.spec.html
@@ -85,6 +85,21 @@
           verifyActiveRoutes(router, ['/a']);
           expect(outlet.children[0].tagName).to.match(/x-users-view/i);
         });
+
+        it('should use `window.replaceState()` when redirecting from action', async() => {
+          const pushSpy = sinon.spy(window.history, 'pushState');
+          const replaceSpy = sinon.spy(window.history, 'replaceState');
+
+          router.setRoutes([
+            {path: '/', action: context => context.redirect('/a')},
+            {path: '/a', component: 'x-users-view'},
+          ]);
+
+          await router.render('/', true);
+
+          expect(pushSpy).to.not.be.called;
+          expect(replaceSpy).to.be.calledOnce;
+        });
       });
     });
   </script>

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -266,6 +266,19 @@
             expect(outlet.children[0].tagName).to.match(/x-users-view/i);
           });
 
+          it('should use `window.replaceState()` when redirecting', async() => {
+            const pushSpy = sinon.spy(window.history, 'pushState');
+            const replaceSpy = sinon.spy(window.history, 'replaceState');
+            router.setRoutes([
+              {path: '/', component: 'x-home-view'},
+              {path: '/people', redirect: '/users'},
+              {path: '/users', component: 'x-users-view'},
+            ]);
+            await router.render('/people', true);
+            expect(pushSpy).to.not.be.called;
+            expect(replaceSpy).to.be.calledOnce;
+          });
+
           it('should set the `route.redirectFrom` property on the route component in case of redirect', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},


### PR DESCRIPTION
Fixes #141

By replacing state, we ensure that pressing "back" does not return us back to the URL which will redirect again. The expected behaviour is already documented in demos, so no demo needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/186)
<!-- Reviewable:end -->
