### PR TITLE
Add vaadin-router-meta custom element class

### DIFF
--- a/src/router-config.js
+++ b/src/router-config.js
@@ -1,5 +1,6 @@
 import CLICK from './triggers/click.js';
 import POPSTATE from './triggers/popstate.js';
 import {Router} from './router.js';
+import './router-meta.js';
 Router.NavigationTrigger = {POPSTATE, CLICK};
 export {Router};

--- a/src/router-meta.js
+++ b/src/router-meta.js
@@ -1,0 +1,17 @@
+/**
+ * The custom element class containing Router meta information,
+ * considered as a read-only part of the public API.
+ *
+ * @class VaadinRouterMeta
+ */
+class VaadinRouterMeta extends HTMLElement {
+  static get is() {
+    return 'vaadin-router-meta';
+  }
+
+  static get version() {
+    return '0.3.0';
+  }
+}
+
+customElements.define(VaadinRouterMeta.is, VaadinRouterMeta);

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -904,6 +904,24 @@
             expect(data[3].oldValue).to.equal('entering');
           });
         });
+
+        describe('vaadin-router-meta', () => {
+          let router;
+
+          beforeEach(() => {
+            router = new Vaadin.Router(outlet);
+          });
+
+          afterEach(() => {
+            router.unsubscribe();
+          });
+
+          it('should expose the version on the `vaadin-router-meta` custom element class', async() => {
+            const meta = customElements.get('vaadin-router-meta');
+            expect(meta).to.be.not.empty;
+            expect(meta.version).to.be.string;
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Part of #32, as the `vaadin-usage-statistics` assumes the Custom Element definition
See https://github.com/vaadin/vaadin-usage-statistics/blob/master/vaadin-usage-statistics.js#L82

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/192)
<!-- Reviewable:end -->
