### PR TITLE
[WIP] Prototype usage statistics for ES module bundle

### DIFF
--- a/index.umd.js
+++ b/index.umd.js
@@ -1,3 +1,2 @@
-import '@vaadin/vaadin-development-mode-detector/vaadin-development-mode-detector.js';
 export {Router} from './src/router-config.js';
 export {default as Resolver} from './src/resolver/resolver.js';

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "IE 11"
   ],
   "dependencies": {
-    "path-to-regexp": "2.2.0"
+    "path-to-regexp": "2.2.0",
+    "@vaadin/vaadin-development-mode-detector": "^1.1.0-alpha2"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,13 +39,14 @@ const config = [
       file: pkg.browser,
       sourcemap: true,
     },
-    plugins
+    plugins,
+    external: id => /@vaadin/.test(id)
   },
 
   // UMD bundle, transpiled (for the browsers that do not support ES modules).
   // Also works in Node.
   {
-    input: 'index.js',
+    input: 'index.umd.js',
     output: {
       format: 'umd',
       file: pkg.main,

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,6 +516,12 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.0.tgz#7180ae2bce061511b48fb9b8fac1b8213ae6718b"
 
+"@polymer/polymer@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.0.2.tgz#626e6f9fae9716b0962ce0211e21df242153eab2"
+  dependencies:
+    "@webcomponents/shadycss" "^1.2.0"
+
 "@polymer/sinonjs@^1.14.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@polymer/sinonjs/-/sinonjs-1.17.1.tgz#e47d3785b7d0e8c29feb97f7e924b0fc597e2e9b"
@@ -1015,6 +1021,16 @@
   dependencies:
     "@types/events" "*"
     "@types/inquirer" "*"
+
+"@vaadin/vaadin-development-mode-detector@^1.1.0-alpha2":
+  version "1.1.0-alpha2"
+  resolved "https://registry.yarnpkg.com/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-1.1.0-alpha2.tgz#541dbaec5f72ce8bfb0a9aa7acae365cd1f87099"
+  dependencies:
+    "@polymer/polymer" "^3.0.0"
+
+"@webcomponents/shadycss@^1.2.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.3.1.tgz#9320a7a86c8abfec97d41a41e82691a0dfc3a13a"
 
 "@webcomponents/webcomponentsjs@^1.0.7":
   version "1.2.0"


### PR DESCRIPTION
DO NOT MERGE

Related to #32 

Currently, `rollup` does not support `experimentalCodeSplitting` for UMD neither IIFE output.
This PR is to raise the discussion regarding whether we want to only have this type of statistics, or something more complex but covering UMD bundle as well is required.

Depends on vaadin/vaadin-development-mode-detector#20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/195)
<!-- Reviewable:end -->
