### PR TITLE
expose the current active routes list in the Router API

### DIFF
--- a/demo/demo-elements/x-breadcrumbs.html
+++ b/demo/demo-elements/x-breadcrumbs.html
@@ -1,0 +1,43 @@
+<link rel="import" href="../../../polymer/polymer-element.html">
+<link rel="import" href="../../../polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../../../polymer/lib/elements/dom-if.html">
+
+<dom-module id="x-breadcrumbs">
+  <template preserve-content>
+    <style>
+      :host {
+        display: block;
+      }
+
+      .delimiter {
+        margin-left: 1em;
+        margin-right: 1em;
+      }
+    </style>
+
+    <template is="dom-repeat" items="[[routes]]">
+      <a href$="[[item.href]]">[[item.title]]</a>
+      <template is="dom-if" if="[[__isNotLastIndexOf(routes, i)]]">
+        <span class="delimiter">&gt;</span>
+      </template>
+    </template>
+  </template>
+  <script>
+    class XBreadcrumbs extends Polymer.Element {
+      static get is() {
+        return 'x-breadcrumbs';
+      }
+
+      static get properties() {
+        return {
+          routes: Array
+        };
+      }
+
+      __isNotLastIndexOf(routes, i) {
+        return i < routes.length;
+      }
+    }
+    window.customElements.define(XBreadcrumbs.is, XBreadcrumbs);
+  </script>
+</dom-module>

--- a/demo/demo-elements/x-breadcrumbs.html
+++ b/demo/demo-elements/x-breadcrumbs.html
@@ -10,17 +10,21 @@
       }
 
       .delimiter {
-        margin-left: 1em;
-        margin-right: 1em;
+        margin-left: 0.5em;
+        margin-right: 0.5em;
       }
     </style>
 
-    <template is="dom-repeat" items="[[routes]]">
-      <a href$="[[item.href]]">[[item.title]]</a>
-      <template is="dom-if" if="[[__isNotLastIndexOf(routes, i)]]">
-        <span class="delimiter">&gt;</span>
+    <dom-repeat items="[[routes]]">
+      <template>
+        <a href$="[[item.breadcrumb.href]]">[[item.breadcrumb.title]]</a>
+        <dom-if if="[[__isNotLastIndexOf(routes, index)]]">
+          <template>
+            <span class="delimiter">&gt;</span>
+          </template>
+        </dom-if>
       </template>
-    </template>
+    </dom-repeat>
   </template>
   <script>
     class XBreadcrumbs extends Polymer.Element {
@@ -35,7 +39,7 @@
       }
 
       __isNotLastIndexOf(routes, i) {
-        return i < routes.length;
+        return i < routes.length - 1;
       }
     }
     window.customElements.define(XBreadcrumbs.is, XBreadcrumbs);

--- a/demo/demo-shell.html
+++ b/demo/demo-shell.html
@@ -19,3 +19,4 @@
 <link rel="import" href="demo-elements/x-user-numeric-view.html">
 <link rel="import" href="demo-elements/x-user-not-found-view.html">
 <link rel="import" href="demo-elements/x-login-view.html">
+<link rel="import" href="demo-elements/x-breadcrumbs.html">

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -381,16 +381,21 @@
         <script>
           window.addEventListener('vaadin-router-route-changed', (event) => {
             const breadcrumbs = document.querySelector('x-breadcrumbs');
-            breadcrumbs.routes = event.detail.router.activeRoutes;
+            breadcrumbs.routes = event.detail.router.activeRoutes
+              .filter(route => !!route.breadcrumb);
           });
 
           const {Router} = window.Vaadin;
 
           const router = new Router(document.getElementById('outlet'));
           router.setRoutes([
-            {path: '/', component: 'x-home-view'},
-            {path: '/users', component: 'x-user-list'},
-            {path: '/users/:user', component: 'x-user-profile'},
+            {path: '/', breadcrumb: {title: 'Home', href: '/'}, children: [
+              {path: '/', component: 'x-home-view'},
+              {path: '/users', breadcrumb: {title: 'Users', href: '/users'}, children: [
+                {path: '/', component: 'x-user-list'},
+                {path: '/:user', breadcrumb: {title: 'Kim', href: '/users/kim'}, component: 'x-user-profile'},
+              ]},
+            ]},
             {path: '(.*)', component: 'x-not-found-view'},
           ]);
         </script>

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -360,6 +360,48 @@
       event Vaadin.Router dispatches <code>vaadin-router-error</code> and
       attaches the error object to the event as <code>event.detail.error</code>.
     </p>
+
+    <h3>Getting the Currently Active Routes Chain</h3>
+    <p>
+      In order to visualize the current in-app location you can use the <em>
+      active routes chain</em> API of Vaadin.Router. The <code>activeRoutes</code>
+      property of a <code>router</code> object is a read-only list of routes
+      that correspond to the last completed navigation. This may be useful for
+      example when creating a breadcrumbs componenent.
+    </p>
+    <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-7" iframe-src="iframe.html">
+      <template preserve-content>
+        <a href="/">Home</a>
+        <a href="/users">All Users</a>
+        <a href="/users/kim">Kim</a>
+        <a href="/about">About</a>
+        <x-breadcrumbs></x-breadcrumbs>>
+        <div id="outlet"></div>
+
+        <script>
+          window.addEventListener('vaadin-router-route-changed', (event) => {
+            const breadcrumbs = document.querySelector('x-breadcrumbs');
+            breadcrumbs.routes = event.detail.router.activeRoutes;
+          });
+
+          const {Router} = window.Vaadin;
+
+          const router = new Router(document.getElementById('outlet'));
+          router.setRoutes([
+            {path: '/', component: 'x-home-view'},
+            {path: '/users', component: 'x-user-list'},
+            {path: '/users/:user', component: 'x-user-profile'},
+            {path: '(.*)', component: 'x-not-found-view'},
+          ]);
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+    <p>
+      In case if navigation fails for any reason (e.g. if no route matched the
+      given pathname), instead of the <code>vaadin-router-route-changed</code>
+      event Vaadin.Router dispatches <code>vaadin-router-error</code> and
+      attaches the error object to the event as <code>event.detail.error</code>.
+    </p>
   </template>
   <script>
     class VaadinRouterLifecycleCallbacksDemos extends DemoReadyEventEmitter(ElementDemo(Polymer.Element)) {

--- a/src/router.js
+++ b/src/router.js
@@ -138,6 +138,18 @@ export class Router extends Resolver {
     this.ready;
     this.ready = Promise.resolve(outlet);
 
+    /**
+     * A read-only list of the currently active routes (starting from the root
+     * down to a leaf of the routes config tree). The list is initially empty
+     * and gets updated after each _completed_ render call. When a render fails
+     * the `activeRoutes` is set to an empty list.
+     *
+     * @public
+     * @type {!Array<Route>}
+     */
+    this.activeRoutes;
+    this.activeRoutes = [];
+
     this.__lastStartedRenderId = 0;
     this.__navigationEventHandler = this.__onNavigationEvent.bind(this);
     this.setOutlet(outlet);
@@ -324,7 +336,8 @@ export class Router extends Resolver {
           this.__removeOldOutletContent();
         }
         this.__previousContext = context;
-        fireRouterEvent('route-changed', {pathname: context.pathname});
+        this.activeRoutes = context.chain;
+        fireRouterEvent('route-changed', {router: this, pathname: context.pathname});
         return this.__outlet;
       })
       .catch(error => {
@@ -333,7 +346,8 @@ export class Router extends Resolver {
             this.__updateBrowserHistory(pathnameOrContext);
           }
           this.__removeOutletContent();
-          fireRouterEvent('error', {error});
+          this.activeRoutes = [];
+          fireRouterEvent('error', {router: this, error});
           throw error;
         }
       });

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -1166,6 +1166,23 @@
           const event = onRouteChanged.args[0][0];
           expect(event.detail.pathname).to.equal('/admin');
         });
+
+        it('should contain the router instance as `event.detail.router`', async() => {
+          router.setRoutes([
+            {path: '/admin', component: 'x-admin-view'},
+          ]);
+
+          const onRouteChanged = sinon.spy();
+          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
+          await router.render('/admin');
+          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
+
+          expect(onRouteChanged).to.have.been.called.once;
+          expect(onRouteChanged.args[0].length).to.equal(1);
+
+          const event = onRouteChanged.args[0][0];
+          expect(event.detail.router).to.equal(router);
+        });
       });
 
       describe('the global `vaadin-router-error` event', () => {
@@ -1198,7 +1215,7 @@
           expect(onError).to.have.been.called.once;
         });
 
-        it('should contain the error as `event.error`', async() => {
+        it('should contain the error as `event.detail.error`', async() => {
           router.setRoutes([
             {path: '/', component: 'x-home-view'},
           ]);
@@ -1214,6 +1231,24 @@
           const event = onError.args[0][0];
           expect(event.detail.error).to.be.an('error');
           expect(event.detail.error.context.pathname).to.equal('/non-existent');
+        });
+
+        it('should contain the router instance as `event.detail.router`', async() => {
+          router.setRoutes([
+            {path: '/', component: 'x-home-view'},
+          ]);
+
+          const onError = sinon.spy();
+          window.addEventListener('vaadin-router-error', onError);
+          await router.render('/non-existent').catch(() => {});
+          window.removeEventListener('vaadin-router-error', onError);
+
+          expect(onError).to.have.been.called.once;
+          expect(onError.args[0].length).to.equal(1);
+
+          const event = onError.args[0][0];
+          expect(event.detail.error).to.be.an('error');
+          expect(event.detail.router).to.equal(router);
         });
       });
     });

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -416,6 +416,60 @@
           });
         });
 
+        describe('router.activeRoutes', () => {
+          let router;
+          beforeEach(() => {
+            router = new Vaadin.Router(outlet);
+          });
+
+          afterEach(() => {
+            router.unsubscribe();
+          });
+
+          it('should be an array', () => {
+            expect(router).to.have.property('activeRoutes')
+              .that.is.an('array');
+          });
+
+          it('should be an empty array initially', () => {
+            expect(router.activeRoutes).to.deep.equal([]);
+          });
+
+          it('should contain the routes chain of the last completed render pass (single route)', async() => {
+            const route = {path: '/', component: 'x-home-view'};
+            router.setRoutes(route);
+
+            await router.ready;
+
+            expect(router.activeRoutes).to.have.lengthOf(1);
+            expect(router.activeRoutes[0]).to.equal(route);
+          });
+
+          it('should contain the routes chain of the last completed render pass (multiple routes)', async() => {
+            const routeC = {path: '/c', component: 'x-c'};
+            const routeB = {path: '/b', component: 'x-b', children: [routeC]};
+            const routeA = {path: '/a', component: 'x-a', children: [routeB]};
+
+            router.setRoutes(routeA);
+            await router.render('/a/b/c');
+
+            expect(router.activeRoutes).to.have.lengthOf(3);
+            expect(router.activeRoutes[0]).to.equal(routeA);
+            expect(router.activeRoutes[1]).to.equal(routeB);
+            expect(router.activeRoutes[2]).to.equal(routeC);
+          });
+
+          it('should be an empty array after a failed render', async() => {
+            router.setRoutes([
+              {path: '/', component: 'x-home-view'}
+            ]);
+            await router.render('/');
+            await router.render('/non-existent').catch(() => {});
+
+            expect(router.activeRoutes).to.deep.equal([]);
+          });
+        });
+
         describe('navigation events', () => {
           let router;
           beforeEach(async() => {


### PR DESCRIPTION
 - add a `Router.activeRoutes` property
 - add to router events' detail object a reference to the router
 - add tests
 - add a demo into the 'Lifecycle callbacks' section

Closes #146 
