### PR TITLE
Remove UMD bundle from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@vaadin/router",
   "version": "0.4.0",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
-  "main": "dist/vaadin-router.umd.js",
-  "browser": "dist/vaadin-router.js",
+  "main": "dist/vaadin-router.js",
   "repository": "vaadin/vaadin-router",
   "keywords": [
     "Vaadin",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,7 +36,7 @@ const config = [
     input: 'index.js',
     output: {
       format: 'es',
-      file: pkg.browser,
+      file: pkg.main,
       sourcemap: true,
     },
     plugins
@@ -48,7 +48,7 @@ const config = [
     input: 'index.js',
     output: {
       format: 'umd',
-      file: pkg.main,
+      file: pkg.main.replace('.js', '.umd.js'),
       sourcemap: true,
       name: 'Vaadin',
       extend: true,


### PR DESCRIPTION
Fixes #207 

The UMD bundles is not processed correctly by `polymer-cli`, which has its own AMD transform, resulting in `window.define` is true, but `window.define.amd` is false.

Leaving ES module as the only entry in package.json for now. For those who need UMD bundle, it is still there but should be included manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/208)
<!-- Reviewable:end -->
