### PR TITLE
Fix the issue when a nested content remains on navigation

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -19,6 +19,12 @@ function isResultNotEmpty(result) {
   return result !== null && result !== undefined;
 }
 
+function copyContextWithoutNext(context) {
+  const copy = Object.assign({}, context);
+  delete copy.next;
+  return copy;
+}
+
 function redirect(context, pathname) {
   const params = Object.assign({}, context.params);
   return {
@@ -186,7 +192,7 @@ export class Router extends Resolver {
 
     if (isFunction(route.children)) {
       callbacks = callbacks
-        .then(() => route.children(Object.assign({}, context, {next: undefined})))
+        .then(() => route.children(copyContextWithoutNext(context)))
         .then(children => {
           // The route.children() callback might have re-written the
           // route.children property instead of returning a value
@@ -544,7 +550,7 @@ export class Router extends Resolver {
     let promises = Promise.resolve();
 
     if (targetContext) {
-      const callbackContext = Object.assign({}, currentContext, {next: undefined});
+      const callbackContext = copyContextWithoutNext(currentContext);
 
       // REVERSE iteration: from Z to A
       for (let i = targetContext.chain.length - 1; i >= currentContext.__divergedChainIndex; i--) {
@@ -569,7 +575,7 @@ export class Router extends Resolver {
 
   __runOnAfterEnterCallbacks(currentContext) {
     let promises = Promise.resolve();
-    const callbackContext = Object.assign({}, currentContext, {next: undefined});
+    const callbackContext = copyContextWithoutNext(currentContext);
 
     // forward iteration: from A to Z
     for (let i = currentContext.__divergedChainIndex; i < currentContext.chain.length; i++) {

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -892,12 +892,12 @@
             'x-b.onBeforeLeave',
             'x-a.onBeforeLeave',
             'x-c.onBeforeEnter',
-            'x-a.onAfterLeave',
             'x-b.onAfterLeave',
+            'x-a.onAfterLeave',
+            'x-b.disconnectedCallback',
             'x-c.connectedCallback',
             'x-c.onAfterEnter',
             'x-a.disconnectedCallback',
-            'x-b.disconnectedCallback',
           ]);
           checkOutlet(['x-c']);
         });

--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -71,6 +71,22 @@
         checkOutlet(['x-a', 'x-b', 'x-c']);
       });
 
+      it('should remove nested route components when the parent route is navigated to', async() => {
+        router.setRoutes([
+          {path: '/a', component: 'x-a', children: [
+            {path: '/b', component: 'x-b'}
+          ]},
+          {path: '/c', component: 'x-c'}
+        ]);
+
+        await router.render('/a/b');
+        await router.render('/c');
+        await router.render('/a');
+
+        verifyActiveRoutes(router, ['/a']);
+        checkOutlet(['x-a']);
+      });
+
       it('when action returns a component result, it is rendered the same way as if it was a component property', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [


### PR DESCRIPTION
 - reverse the order of calling the onAfterLeave callbacks: now from the leafs to the root
 - call 'removeChild' after 'onAfterLeave' to make sure the nested children are removed from the cached view components

Fixes #206

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/214)
<!-- Reviewable:end -->
