### PR TITLE
Use `location` and `commands` instead of `context` in the public API

### DIFF
--- a/demo/demo-elements/user.bundle.html
+++ b/demo/demo-elements/user.bundle.html
@@ -7,7 +7,7 @@
     </style>
 
     <h1>User Profile</h1>
-    <p>User id: <b>[[route.params.id]]</b>. This view was loaded using HTML bundle.</p>
+    <p>User id: <b>[[location.params.id]]</b>. This view was loaded using HTML bundle.</p>
   </template>
 </dom-module>
 

--- a/demo/demo-elements/user.bundle.js
+++ b/demo/demo-elements/user.bundle.js
@@ -7,7 +7,7 @@
       const tpl = document.createElement('template');
       tpl.innerHTML = `
         <h1>User Profile</h1>
-        <p>User id: <b>[[route.params.id]]</b>. This view was loaded using JS bundle.</p>
+        <p>User id: <b>[[location.params.id]]</b>. This view was loaded using JS bundle.</p>
       `;
       return tpl;
     }

--- a/demo/demo-elements/x-image-view.html
+++ b/demo/demo-elements/x-image-view.html
@@ -6,7 +6,7 @@
       }
     </style>
 
-    <div style$="height: [[route.params.size]]px; width: [[route.params.size]]px; background: [[route.params.color]];"></div>
+    <div style$="height: [[location.params.size]]px; width: [[location.params.size]]px; background: [[location.params.color]];"></div>
   </template>
   <script>
     class XImageView extends Polymer.Element {
@@ -16,7 +16,7 @@
 
       static get properties() {
         return {
-          route: Object
+          location: Object
         };
       }
     }

--- a/demo/demo-elements/x-knowledge-base.html
+++ b/demo/demo-elements/x-knowledge-base.html
@@ -1,6 +1,6 @@
 <dom-module id="x-knowledge-base">
   <template preserve-content>
-    Knowledge base path: '[[route.params.path]]'
+    Knowledge base path: '[[location.params.path]]'
   </template>
   <script>
     class XKnowledgeBase extends Polymer.Element {
@@ -10,7 +10,7 @@
 
       static get properties() {
         return {
-          route: Object
+          location: Object
         };
       }
     }

--- a/demo/demo-elements/x-login-view.html
+++ b/demo/demo-elements/x-login-view.html
@@ -22,7 +22,7 @@
           window.authorized = true;
           window.dispatchEvent(
             new CustomEvent('vaadin-router-go',
-              {detail: {pathname: this.route.params.to || '/'}}));
+              {detail: {pathname: this.location.params.to || '/'}}));
         }
       }
 

--- a/demo/demo-elements/x-profile-view.html
+++ b/demo/demo-elements/x-profile-view.html
@@ -2,8 +2,8 @@
 
 <dom-module id="x-profile-view">
   <template preserve-content>
-    User ID: [[route.params.id]]<br/>
-    <code>/user</code> or <code>/users</code>: [[route.params.0]]
+    User ID: [[location.params.id]]<br/>
+    <code>/user</code> or <code>/users</code>: [[location.params.0]]
   </template>
   <script>
     class XProfileView extends Polymer.Element {
@@ -13,7 +13,7 @@
 
       static get properties() {
         return {
-          route: Object
+          location: Object
         };
       }
     }

--- a/demo/demo-elements/x-user-not-found-view.html
+++ b/demo/demo-elements/x-user-not-found-view.html
@@ -9,7 +9,7 @@
     </style>
 
     <h1>The princess is in another castle</h1>
-    <p>You've come to <code>[[route.pathname]]</code>, but alas, there is
+    <p>You've come to <code>[[location.pathname]]</code>, but alas, there is
       nothing there.</p>
   </template>
   <script>
@@ -21,7 +21,7 @@
 
         static get properties() {
           return {
-            route: Object
+            location: Object
           };
         }
       }

--- a/demo/demo-elements/x-user-numeric-view.html
+++ b/demo/demo-elements/x-user-numeric-view.html
@@ -9,7 +9,7 @@
     </style>
 
     <h1>User Profile</h1>
-    <p>ID: [[route.params.0]]</p>
+    <p>ID: [[location.params.0]]</p>
   </template>
   <script>
     (() => {
@@ -20,7 +20,7 @@
 
         static get properties() {
           return {
-            route: Object
+            location: Object
           };
         }
       }

--- a/demo/demo-elements/x-user-profile.html
+++ b/demo/demo-elements/x-user-profile.html
@@ -9,7 +9,7 @@
     </style>
 
     <h1>User Profile</h1>
-    <p>Name: [[route.params.user]]</p>
+    <p>Name: [[location.params.user]]</p>
   </template>
   <script>
     (() => {
@@ -20,7 +20,7 @@
 
         static get properties() {
           return {
-            route: Object
+            location: Object
           };
         }
       }

--- a/demo/vaadin-router-getting-started-demos.html
+++ b/demo/vaadin-router-getting-started-demos.html
@@ -68,21 +68,21 @@
     <p>
       Route components can be any Web Components regardless of how they are
       built: vanilla JavaScript, Polymer, Stencil, SkateJS, Angular, Vue, etc.
-      The only convention is that the <code>route</code> object property is set
-      by the router on the component when rendering:
-      <marked-element>
-        <script type="text/markdown">
-          ```js
-          {
-            route: {
-              pathname: '/',
-              params: {},
-              /* any other route-specific info */
-            }
-          }
-          ```
-        </script>
-      </marked-element>
+    </p>
+    <p>
+      Vaadin.Router follows the lifecycle callbacks convention described in
+      <a href="..#/classes/Vaadin.WebComponentInterface">WebComponentInterface</a>:
+      if a route component defines any of these callback methods, Vaadin.Router
+      will call them at the appropriate points in the navigation lifecycle.
+      See the <a href="#vaadin-router-lifecycle-callbacks-demos">Lifecycle
+      Callbacks</a> section for more details.
+    </p>
+    <p>
+      In addition to that Vaadin.Router also sets a
+      <a href="..#/classes/Vaadin.Router.Location"><code>location</code>
+      property</a> on every route Web Component so that you could access the
+      current location details via an instance property (e.g.
+      <code>this.location.pathname</code>).
     </p>
 
     <h3>Fallback Routes (404)</h3>
@@ -95,7 +95,7 @@
       the route resolution is based on the first match, the fallback route
       should always be <strong>after</strong> other alternatives.</p>
     <p>The path that leads to the fallback route is available to the route
-      component via the <code>route.pathname</code> property.</p>
+      component via the <code>location.pathname</code> property.</p>
     <vaadin-demo-snippet id="vaadin-router-getting-started-demo-2" iframe-src="iframe.html">
       <template preserve-content>
         <a href="/">Home</a>

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -377,7 +377,7 @@
             const params = event.detail.params;
 
             const breadcrumbs = document.querySelector('x-breadcrumbs');
-            breadcrumbs.items = router.activeRoutes
+            breadcrumbs.items = router.location.routes
               .filter(route => !!route.xBreadcrumb)
               .map(route => {
                 return {

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -211,7 +211,7 @@
         <dom-module id="x-user-manage">
           <template>
             <h1>Manage user</h1>
-            <p>User name: [[route.params.user]]</p>
+            <p>User name: [[location.params.user]]</p>
             <a href="/user/delete">Delete user</a>
           </template>
         </dom-module>

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -21,7 +21,7 @@
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterEnter">
-          onAfterEnter(location)</a>: Promise | void</code></b>
+          onAfterEnter(location)</a>: void</code></b>
         </li>
         <li>
           <b><code>
@@ -32,7 +32,7 @@
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterLeave">
-            onAfterLeave(location)</a>: Promise | void</code></b>
+            onAfterLeave(location)</a>: void</code></b>
         </li>
         <hr/>
         <li>
@@ -138,9 +138,7 @@
       interactions.
     </p>
     <p>
-      Any value returned from this callback is ignored. However, if it returns
-      a promise, the router waits until the promise is resolved before
-      proceeding with the navigation.
+      Any value returned from this callback is ignored.
     </p>
     <p>
       See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterEnter">
@@ -259,9 +257,7 @@
       from the view.
     </p>
     <p>
-      Any value returned from this callback is ignored. However, if it returns
-      a promise, the router waits until the promise is resolved before
-      completing with the navigation.
+      Any value returned from this callback is ignored.
     </p>
     <p>
       See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterLeave">

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -8,40 +8,68 @@
 
     <h3>Lifecycle Callbacks</h3>
     <p>
-      All Web Components in Vaadin.Router follow the same lifecycle. <em>Lifecycle
-      callbacks</em> allow adding custom logic to any point of it:
+      Vaadin.Router manages the lifecycle of all route Web Components.
+      <em>Lifecycle callbacks</em> allow you to add custom logic to any point of
+      this lifecycle:
       <ul>
-        <li><b><code>onBeforeEnter(context): Promise | Cancel | Redirect | void</code></b></li>
-        <li><b><code>onAfterEnter(context): Promise | void</code></b></li>
-        <li><b><code>onBeforeLeave(context): Promise | Cancel | void</code></b></li>
-        <li><b><code>onAfterLeave(context): Promise | void</code></b></li>
+        <li>
+          <b><code>
+          <a href="..#/classes/Vaadin.WebComponentInterface#method-onBeforeEnter">
+          onBeforeEnter(location, commands)</a>: Promise | Prevent | Redirect |
+          void</code></b>
+        </li>
+        <li>
+          <b><code>
+          <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterEnter">
+          onAfterEnter(location)</a>: Promise | void</code></b>
+        </li>
+        <li>
+          <b><code>
+          <a href="..#/classes/Vaadin.WebComponentInterface#method-onBeforeLeave">
+          onBeforeLeave(location, commands)</a>: Promise | Prevent | void
+          </code></b>
+        </li>
+        <li>
+          <b><code>
+          <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterLeave">
+            onAfterLeave(location)</a>: Promise | void</code></b>
+        </li>
         <hr/>
-        <li>the <code>'vaadin-router-route-changed'</code> / <code>'vaadin-router-error'</code>
-          events on the <code>window</code></li>
+        <li>
+          the <code>'vaadin-router-location-changed'</code> /
+          <code>'vaadin-router-error'</code> events on the <code>window</code>
+        </li>
       </ul>
-      Vaadin.Router lifecycle callbacks can be defined as methods on the Web Component
+      Vaadin.Router lifecycle callbacks can be defined as methods on the route
+      Web Component
       <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-definition"
       target="_blank" rel="noopener">class definition</a> in a similar way as
-      native custom element callbacks (like <code>disconnectedCallback()</code>).
+      the native custom element callbacks (like
+      <code>disconnectedCallback()</code>).
     </p>
-    <h3><code>onBeforeEnter(context)</code></h3>
+
+    <h3><code>onBeforeEnter(location, commands)</code></h3>
     <p>
-      The component has matched the current path, the instance has been created and is about
-      to be rendered to the DOM. At this point there is no guarantee that the navigation
-      into the view will actually happen (because another callback may interfere).
+      The component's route has matched the current path, an instance of the
+      component has been created and is about to be inserted into the DOM. Use
+      this callback to create a route guard (e.g. redirect to the login page
+      if the user is not logged in).
     </p>
     <p>
-      This callback may return special values to produce following effects:
+      At this point there is yet <strong>no guarantee that the navigation into
+      this view will actually happen</strong> because another route's callback
+      may interfere.
     </p>
-    <ul>
-      <li>prevent navigation to the view: <b><code>return context.cancel()</code></b></li>
-      <li>redirect to the different path: <b><code>return context.redirect('/new/path')</code></b></li>
-      <li>delay navigation and rendering: <b><code>return new Promise(...)</code></b></li>
-      <li>any other return value is ignored, and the navigation continues.</li>
-    </ul>
     <p>
-      See <a href="../#/classes/Vaadin.WebComponentInterface#method-onBeforeEnter" target="_blank">
-      API documentation</a> for the available <code>context</code> object properties.
+      This callback may return a <em>redirect</em> (<code>return
+      commands.redirect('/new/path')</code>) or a <em>prevent</em> (<code>return
+      commands.prevent()</code>) router command. If it returns a promise, the
+      router waits until the promise is resolved before proceeding with the
+      navigation.
+    </p>
+    <p>
+      See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onBeforeEnter">
+      API documentation</a> for more details.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-1" iframe-src="iframe.html">
       <template preserve-content>
@@ -100,24 +128,23 @@
         </dom-module>
       </template>
     </vaadin-demo-snippet>
-    <h3><code>onAfterEnter(context)</code></h3>
+
+    <h3><code>onAfterEnter(location)</code></h3>
     <p>
-      The element has matched the current path and has been rendered. At
-      this point it is certain that navigation won't be prevented or redirected.
-      This callback is called asynchronously after the native
-      <a href="https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions"
-      target="_blank" rel="noopener"><b><code>connectedCallback()</code></b></a> defined by the Custom Elements spec.
+      The component's route has matched the current path and an instance of the
+      component has been rendered into the DOM. At this point it is certain that
+      navigation won't be prevented or redirected. Use this callback to
+      process route params and initialize the view so that it's ready for user
+      interactions.
     </p>
     <p>
-      This callback has the following restrictions:
+      Any value returned from this callback is ignored. However, if it returns
+      a promise, the router waits until the promise is resolved before
+      proceeding with the navigation.
     </p>
-    <ul>
-      <li>may not prevent nor redirect navigation,</li>
-      <li>can return a <b>Promise</b>, but it won't delay the rendering.</li>
-    </ul>
     <p>
-      See <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterEnter" target="_blank">
-      API documentation</a> for the available <code>context</code> object properties.
+      See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterEnter">
+      API documentation</a> for more details.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-2" iframe-src="iframe.html">
       <template preserve-content>
@@ -157,29 +184,29 @@
         </dom-module>
       </template>
     </vaadin-demo-snippet>
-    <h3><code>onBeforeLeave(context)</code></h3>
+
+    <h3><code>onBeforeLeave(location, commands)</code></h3>
     <p>
-      The element does not match the current path anymore and is about to be
-      removed from the DOM. Even if this callback does not prevent the navigation, at
-      this point there is no guarantee that the navigation away from the
-      view will actually happen (because another callback may also interfere).
+      The component's route does not match the current path anymore and the
+      component is about to be removed from the DOM. Use this callback to
+      prevent the navigation if necessary like in the demo below. Note that the
+      user is still able to copy and open that URL manually in the browser.
     </p>
     <p>
-      This callback may return special values to produce following effects:
-    </p>
-    <ul>
-      <li>prevent navigation to the view: <code>return context.cancel()</code></li>
-      <li>delay the component removal: <code>return new Promise(...)</code></li>
-      <li>any other return value is ignored, and the navigation continues.</li>
-    </ul>
-    <p>
-      See <a href="../#/classes/Vaadin.WebComponentInterface#method-onBeforeLeave" target="_blank">
-      API documentation</a> for the available <code>context</code> object properties.
+      Even if this callback does not prevent the navigation, at this point there
+      is yet <strong>no guarantee that the navigation away from this view will
+      actually happen</strong> because another route's callback may also
+      interfere.
     </p>
     <p>
-      The demo below illustrates how to protect the user from switching to the different URL
-      without performing some needed actions while staying within current view. Note that
-      the user is still able to copy and open that URL manually in the browser.
+      This callback may return a <em>prevent</em> (<code>return
+      commands.prevent()</code>) router command. If it returns a promise, the
+      router waits until the promise is resolved before proceeding with the
+      navigation.
+    </p>
+    <p>
+      See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onBeforeLeave">
+      API documentation</a> for more details.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-3" iframe-src="iframe.html">
       <template preserve-content>
@@ -221,24 +248,24 @@
         </script>
       </template>
     </vaadin-demo-snippet>
-    <h3><code>onAfterLeave(context)</code></h3>
+
+    <h3><code>onAfterLeave(location)</code></h3>
     <p>
-      The element does not match the current path anymore and is about to be
-      removed from the DOM. When this callback is executed, the navigation cannot be interrupted anymore.
+      The component's route does not match the current path anymore and the
+      component has been removed from the DOM. At this point it is certain that
+      navigation won't be prevented. Use this callback to clean-up and perform
+      any custom actions that leaving a view should trigger. For example, the
+      demo below auto-saves any unsaved changes when the user navigates away
+      from the view.
     </p>
     <p>
-      This callback may return special values to produce following effects:
-    </p>
-    <ul>
-      <li>delay the component removal: <code>return new Promise(...)</code></li>
-      <li>any other return value is ignored, and the navigation continues.</li>
-    </ul>
-    <p>
-      See <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterLeave" target="_blank">
-      API documentation</a> for the available <code>context</code> object properties.
+      Any value returned from this callback is ignored. However, if it returns
+      a promise, the router waits until the promise is resolved before
+      completing with the navigation.
     </p>
     <p>
-      The demo below illustrates how is it possible to autosave changes when navigating away from the view.
+      See the <a href="../#/classes/Vaadin.WebComponentInterface#method-onAfterLeave">
+      API documentation</a> for more details.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-4" iframe-src="iframe.html">
       <template preserve-content>
@@ -281,49 +308,11 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Prevent Navigation Using <code>onBeforeEnter(context)</code></h3>
-    <p>
-      The navigation can also be prevented by returning the same result from <code>onBeforeEnter()</code> callback.
-      Another option is to redirect the user from this callback: <code>return context.redirect('/new/path')</code>.
-      See the <a href="#vaadin-router-redirect-demos">Redirect</a> section for detailed example.
-    </p>
-    <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-5" iframe-src="iframe.html">
-      <template preserve-content>
-        <a href="/">Home</a>
-        <a href="/danger">Danger</a>
-        <div id="outlet"></div>
-        <script>
-          Polymer({
-            is: 'x-dangerous',
-            onBeforeEnter: function(context) {
-              if (!confirm('Do you really want to know it?')) {
-                return context.cancel();
-              }
-            }
-          });
-          // import {Router} from '@vaadin/router'; // for Webpack / Polymer CLI
-          // const Router = Vaadin.Router; // for vaadin-router.umd.js
-
-          const router = new Router(document.getElementById('outlet'));
-          router.setRoutes([
-            {path: '/', component: 'x-home-view'},
-            {path: '/danger', component: 'x-dangerous'}
-          ]);
-        </script>
-        <dom-module id="x-dangerous">
-          <template>
-            <h1>Santa Claus Doesn't Exist</h1>
-            <p>Sorry.</p>
-          </template>
-        </dom-module>
-      </template>
-    </vaadin-demo-snippet>
-
     <h3>Listen to Global Navigation Events</h3>
     <p>
       In order to react to route changes in other parts of the app (outside of
       route components), you can add an event listener for the <code>
-      vaadin-router-route-changed</code> events on the <code>window</code>.
+      vaadin-router-location-changed</code> events on the <code>window</code>.
       Vaadin.Router dispatches such events every time after navigating to a
       new path.
     </p>
@@ -357,20 +346,22 @@
     </vaadin-demo-snippet>
     <p>
       In case if navigation fails for any reason (e.g. if no route matched the
-      given pathname), instead of the <code>vaadin-router-route-changed</code>
+      given pathname), instead of the <code>vaadin-router-location-changed</code>
       event Vaadin.Router dispatches <code>vaadin-router-error</code> and
       attaches the error object to the event as <code>event.detail.error</code>.
     </p>
 
-    <h3>Getting the Currently Active Routes Chain</h3>
+    <h3>Getting the Current Location</h3>
     <p>
       When handling Vaadin Router events, you can access the router instance via
-      <code>event.detail.router</code>. For example, the <em>active routes chain
-      </em> API of Vaadin.Router is available via the <code>activeRoutes</code>
-      property of a <code>router</code> object. It is a read-only list of routes
-      that correspond to the last completed navigation, which  may be useful for
-      example when creating a breadcrumbs component to visualize the current
-      in-app location.
+      <code>event.detail.router</code>, and the current location via <code>
+      event.detail.location</code> (which is a shorthand for
+      <code>event.detail.router.location</code>). The
+      <a href="..#/classes/Vaadin.Router.Location"><code>location</code></a>
+      object has all details about the current router state. For example,
+      <code>location.routes</code> is a read-only list of routes that correspond
+      to the last completed navigation, which  may be useful for example when
+      creating a breadcrumbs component to visualize the current in-app location.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-7" iframe-src="iframe.html">
       <template preserve-content>
@@ -417,7 +408,7 @@
       The router configuration allows you to add any custom properties to route
       objects. The example above uses that to set a custom <code>xBreadcrumb</code>
       property on the routes that we want to show up in breadcrumbs. That
-      property is used later when processing the <code>vaadin-router-route-changed
+      property is used later when processing the <code>vaadin-router-location-changed
       </code> events.
     </p>
   </template>

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -219,10 +219,10 @@
         <script>
           Polymer({
             is: 'x-user-manage',
-            onBeforeLeave: function(context) {
-              if (context.pathname.indexOf('user/delete') > 0) {
+            onBeforeLeave: function(location, commands) {
+              if (location.pathname.indexOf('user/delete') > 0) {
                 if (!window.confirm('Are you sure you want to delete this user?')) {
-                  return context.cancel();
+                  return commands.prevent();
                 }
               }
             }

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -360,7 +360,7 @@
       <a href="..#/classes/Vaadin.Router.Location"><code>location</code></a>
       object has all details about the current router state. For example,
       <code>location.routes</code> is a read-only list of routes that correspond
-      to the last completed navigation, which  may be useful for example when
+      to the last completed navigation, which may be useful for example when
       creating a breadcrumbs component to visualize the current in-app location.
     </p>
     <vaadin-demo-snippet id="vaadin-router-lifecycle-events-demos-7" iframe-src="iframe.html">

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -326,9 +326,9 @@
         <div id="outlet"></div>
 
         <script>
-          window.addEventListener('vaadin-router-route-changed', (event) => {
+          window.addEventListener('vaadin-router-location-changed', (event) => {
             const breadcrumbs = document.querySelector('#breadcrumbs');
-            breadcrumbs.innerHTML = `You are at '${event.detail.pathname}'`;
+            breadcrumbs.innerHTML = `You are at '${event.detail.location.pathname}'`;
           });
 
           // import {Router} from '@vaadin/router'; // for Webpack / Polymer CLI
@@ -372,9 +372,9 @@
         <div id="outlet"></div>
 
         <script>
-          window.addEventListener('vaadin-router-route-changed', (event) => {
+          window.addEventListener('vaadin-router-location-changed', (event) => {
             const router = event.detail.router;
-            const params = event.detail.params;
+            const params = event.detail.location.params;
 
             const breadcrumbs = document.querySelector('x-breadcrumbs');
             breadcrumbs.items = router.location.routes

--- a/demo/vaadin-router-lifecycle-callbacks-demos.html
+++ b/demo/vaadin-router-lifecycle-callbacks-demos.html
@@ -15,24 +15,24 @@
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onBeforeEnter">
-          onBeforeEnter(location, commands)</a>: Promise | Prevent | Redirect |
+          onBeforeEnter(location, commands, router)</a>: Promise | Prevent | Redirect |
           void</code></b>
         </li>
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterEnter">
-          onAfterEnter(location)</a>: void</code></b>
+          onAfterEnter(location, commands, router)</a>: void</code></b>
         </li>
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onBeforeLeave">
-          onBeforeLeave(location, commands)</a>: Promise | Prevent | void
+          onBeforeLeave(location, commands, router)</a>: Promise | Prevent | void
           </code></b>
         </li>
         <li>
           <b><code>
           <a href="..#/classes/Vaadin.WebComponentInterface#method-onAfterLeave">
-            onAfterLeave(location)</a>: void</code></b>
+            onAfterLeave(location, commands, router)</a>: void</code></b>
         </li>
         <hr/>
         <li>
@@ -48,7 +48,7 @@
       <code>disconnectedCallback()</code>).
     </p>
 
-    <h3><code>onBeforeEnter(location, commands)</code></h3>
+    <h3><code>onBeforeEnter(location, commands, router)</code></h3>
     <p>
       The component's route has matched the current path, an instance of the
       component has been created and is about to be inserted into the DOM. Use
@@ -129,7 +129,7 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3><code>onAfterEnter(location)</code></h3>
+    <h3><code>onAfterEnter(location, commands, router)</code></h3>
     <p>
       The component's route has matched the current path and an instance of the
       component has been rendered into the DOM. At this point it is certain that
@@ -183,7 +183,7 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3><code>onBeforeLeave(location, commands)</code></h3>
+    <h3><code>onBeforeLeave(location, commands, router)</code></h3>
     <p>
       The component's route does not match the current path anymore and the
       component is about to be removed from the DOM. Use this callback to
@@ -247,7 +247,7 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3><code>onAfterLeave(location)</code></h3>
+    <h3><code>onAfterLeave(location, commands, router)</code></h3>
     <p>
       The component's route does not match the current path anymore and the
       component has been removed from the DOM. At this point it is certain that

--- a/demo/vaadin-router-redirect-demos.html
+++ b/demo/vaadin-router-redirect-demos.html
@@ -81,9 +81,9 @@
           window.authorized = false;
 
           class XAdminView extends HTMLElement {
-            onBeforeEnter(context) {
+            onBeforeEnter(locatoin, commands) {
               if (!window.authorized) {
-                return context.redirect('/login/' + encodeURIComponent(context.pathname));
+                return commands.redirect('/login/' + encodeURIComponent(location.pathname));
               }
             }
           }

--- a/demo/vaadin-router-redirect-demos.html
+++ b/demo/vaadin-router-redirect-demos.html
@@ -18,26 +18,12 @@
       and cannot be reached by pressing the "Back" browser button. Unconditional
       redirects work for routes both with and without parameters.
     <p>
-      The original path is available to the view Web Component as the
-      <code>route.redirectFrom</code> string property, as described in the snippet below.
-      <a href="#vaadin-router-route-actions-demos">Route Actions</a> can access
-      the original path reference as <code>context.from</code>.
+      The original path is available to route Web Components as the
+      <a href="..#/classes/Vaadin.Router.Location#property-redirectFrom">
+      <code>location.redirectFrom</code></a> string property, and to custom
+      <a href="#vaadin-router-route-actions-demos">route actions</a> &ndash;
+      as <code>context.redirectFrom</code>.
     </p>
-    <marked-element>
-      <script type="text/markdown">
-        ```js
-        {
-          route: {
-            pathname: '/user/guest',
-            redirectFrom: '/u/guest', /* the path which redirected */
-            params: {
-              id: 'guest'
-            }
-          }
-        }
-        ```
-      </script>
-    </marked-element>
     <p>
       Note: If a route has both the <code>redirect</code> and <code>action</code>
       properties, <code>action</code> is executed first and if it does not
@@ -69,10 +55,11 @@
 
     <h3>Dynamic Redirects</h3>
     <p>
-      Vaadin.Router allows redirecting to another route dynamically based on
-      a condition evaluated at the run time. In order to do that, add <code>
-      return context.redirect('/new/path')</code> into the <code>onBeforeEnter()
-      </code> lifecycle callback of the route Web Component.
+      Vaadin.Router allows redirecting to another path dynamically based on
+      a condition evaluated at the run time. In order to do that, <code>
+      return commands.redirect('/new/path')</code> from the
+      <a href="#vaadin-router-lifecycle-callbacks-demos"><code>onBeforeEnter()
+      </code></a> lifecycle callback of the route Web Component.
     </p>
     <p>
       It is also possible to redirect from a custom route action. The demo below
@@ -123,10 +110,10 @@
 
     <h3>Navigation from JavaScript</h3>
     <p>
-      If you want to redirect users to another route in response to a user
+      If you want to send users to another path in response to a user
       action (outside of a lifecycle callback), you can do that by using the
-      static <code>Router.go('/to/path')</code> method on the Vaadin.Router
-      class.
+      static <a href="..#/classes/Vaadin.Router#staticmethod-go"><code>
+      Router.go('/to/path')</code></a> method on the Vaadin.Router class.
     </p>
     <vaadin-demo-snippet id="vaadin-router-redirect-demos-3" iframe-src="iframe.html">
       <template preserve-content>

--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -211,9 +211,9 @@
           // import {Router} from '@vaadin/router'; // for Webpack / Polymer CLI
           // const Router = Vaadin.Router; // for vaadin-router.umd.js
 
-          const redirect = context => {
+          const redirect = (context, commands) => {
             context.params.user += ' (redirected)';
-            return context.redirect('/users/:user');
+            return commands.redirect('/users/:user');
           };
 
           const router = new Router(document.getElementById('outlet'));
@@ -252,11 +252,11 @@
           // import {Router} from '@vaadin/router'; // for Webpack / Polymer CLI
           // const Router = Vaadin.Router; // for vaadin-router.umd.js
 
-          const render = context => {
+          const render = (context, commands) => {
             if (context.params.user === 'admin') {
-              return context.component('x-user-profile');
+              return commands.component('x-user-profile');
             }
-            const stubElement = context.component('h3');
+            const stubElement = commands.component('h3');
             stubElement.innerHTML = 'Access denied';
             return stubElement;
           };

--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -31,7 +31,7 @@
       check other matching routes.
     </p>
     <p>
-      The <code>action(context)</code> function receives a <code>context</code>
+      The <code>action(context, commands)</code> function receives a <code>context</code>
       parameter with the following properties:
       <ul>
         <li><code>context.pathname</code> [string] the pathname being resolved
@@ -39,34 +39,55 @@
         <li><code>context.params</code> [object] the route parameters</li>
         <li><code>context.route</code> [object] the route that is currently being rendered</li>
         <li><code>context.next()</code> [function] function for asynchronously getting the next route contents from the resolution chain (if any)</li>
-        <li><code>context.redirect(path)</code> [function] that creates a redirect data for the path specified.
-        This data can be returned from <code>action</code> to perform an actual redirect</li>
-        <li><code>context.component(component)</code> [function] that creates a new <code>HTMLElement</code>
-          with current context. If an action returns this element, the behavior is the same as for <code>component</code> route property:
-          the action result will be rendered, if the action is in a child route,
-          the result will be rendered as light dom child of the component from a parent route.
+      </ul>
+
+      The <code>commands</code> is a helper object with methods to create return
+      values for the action:
+      <ul>
+        <li>
+          <code>return commands.redirect('/new/path')</code> create and return a
+          redirect command for the specified path. This command should be
+          returned from the <code>action</code> to perform an actual redirect.
+        </li>
+        <li>
+          <code>return commands.prevent()</code> create and return a prevent
+          command.  This command should be returned from the <code>action</code>
+          to instruct router to stop the current navigation and remain at the
+          previous location.
+        </li>
+        <li>
+          <code>return commands.component('tag-name')</code> create and return a
+          new <code>HTMLElement</code> that will be rendered into the router
+          outlet. Using the <code>component</code> command ensures that the
+          created component is initialize as a Vaadin.Router view (i.e. the
+          <code>location</code> property is set according to the current router
+          context.
+          <br/>
+          If an action returns this element, the behavior is the same as for
+          <code>component</code> route property: the action result will be
+          rendered, if the action is in a child route, the result will be
+          rendered as light dom child of the component from a parent route.
         </li>
       </ul>
       The supported return values are
       <ul>
-        <li>an instance of <code>HTMLElement</code></li>
-        <li>a <em>redirect</em> object, i.e. an <code>object</code> with a
-          <code>redirect</code> property that looks like:
-          <marked-element>
-            <script type="text/markdown">
-              ```js
-              {
-                route: {
-                  pathname: '/new/path/:param',
-                  from: '/old/path/:param',
-                  params: /* the parameters object (if any) */
-                }
-              }
-              ```
-            </script>
-          </marked-element>
+        <li>
+          an instance of <code>HTMLElement</code> (e.g. created with
+          <code>commands.component('tag-name')</code>
         </li>
-        <li><code>null</code> or <code>undefined</code></li>
+        <li>
+          a <em>redirect</em> command created with
+          <code>commands.redirect('/new/path')</code>
+        </li>
+        <li>
+          a <em>prevent</em> command created with <code>commands.prevent()</code>
+        </li>
+        <li>
+          <code>null</code> or <code>undefined</code>
+        </li>
+        <li>
+          a promise that resolves to any of the above
+        </li>
       </ul>
     </p>
     <p>
@@ -166,11 +187,12 @@
 
     <h3>Redirecting from an Action</h3>
     <p>
-      <code>action()</code> can use its <code>context</code> parameter to influence
-      the route resolution result.
-      First demo had demonstrated the <code>context.next()</code> usage,
-      this demo demonstrates <code>context.redirect(path)</code> method usage
-      that allows you to redirect to any other defined route by using its path.
+      <code>action()</code> can return a command created using the
+      <code>commands</code> parameter methods to affect the route resolution
+      result.
+      The first demo had demonstrated the <code>context.next()</code> usage,
+      this demo demonstrates using <code>commands.redirect(path)</code> to
+      redirect to any other defined route by using its path.
       All the parameters in current context will be passed to the redirect target.
     </p>
     <p>
@@ -207,13 +229,14 @@
 
     <h3>Returning Custom Element as an Action Result</h3>
     <p>
-      Another thing that <code>action()</code> can do with <code>context</code>
-      parameter is to create a custom element with current context.
-      All the parameters in current context will be passed to the rendered element.
+      Another command available to a custom <code>action()</code> is
+      <code>commands.component('tag-name')</code>. It is useful to create a
+      custom element with current context. All the parameters in current context
+      will be passed to the rendered element.
     </p>
     <p>
-      Note: If the only thing your action does is custom element creation, it can
-      be replaced with <code>component</code> property of the route.
+      Note: If the only thing your action does is custom element creation, it
+      can be replaced with <code>component</code> property of the route.
       See <a href="#vaadin-router-getting-started-demos">Getting Started</a>
       section for examples.
     </p>

--- a/demo/vaadin-router-route-actions-demos.html
+++ b/demo/vaadin-router-route-actions-demos.html
@@ -51,7 +51,7 @@
         </li>
         <li>
           <code>return commands.prevent()</code> create and return a prevent
-          command.  This command should be returned from the <code>action</code>
+          command. This command should be returned from the <code>action</code>
           to instruct router to stop the current navigation and remain at the
           previous location.
         </li>
@@ -59,7 +59,7 @@
           <code>return commands.component('tag-name')</code> create and return a
           new <code>HTMLElement</code> that will be rendered into the router
           outlet. Using the <code>component</code> command ensures that the
-          created component is initialize as a Vaadin.Router view (i.e. the
+          created component is initialized as a Vaadin.Router view (i.e. the
           <code>location</code> property is set according to the current router
           context.
           <br/>

--- a/demo/vaadin-router-route-parameters-demos.html
+++ b/demo/vaadin-router-route-parameters-demos.html
@@ -73,8 +73,8 @@
         <dom-module id="x-project-view">
           <template>
             <h1>Project</h1>
-            <p>ID: [[route.params.id]]</p>
-            <code>/project</code> or <code>/projects</code>: [[route.params.0]]
+            <p>ID: [[location.params.id]]</p>
+            <code>/project</code> or <code>/projects</code>: [[location.params.0]]
           </template>
         </dom-module>
 

--- a/demo/vaadin-router-route-parameters-demos.html
+++ b/demo/vaadin-router-route-parameters-demos.html
@@ -54,14 +54,17 @@
     </vaadin-demo-snippet>
 
     <h3>Accessing Route Parameters</h3>
-    <p>Route parameters are bound to the <code>route.params</code> property of
-      the route Web Component (the <code>route</code> property is set on the
-      route component by Vaadin.Router).</p>
+    <p>
+      Route parameters are bound to the <code>location.params</code> property of
+      the route Web Component
+      (<a href="..#/classes/Vaadin.Router.Location"><code>location</code></a>
+      is set on the route components by Vaadin.Router).
+    </p>
     <ul>
       <li>Named parameters are accessible by a string key, e.g.
-        <code>route.params.id</code> or <code>route.params['id']</code></li>
+        <code>location.params.id</code> or <code>location.params['id']</code></li>
       <li>Unnamed parameters are accessible by a numeric index, e.g.
-        <code>route.params[0]</code></li>
+        <code>location.params[0]</code></li>
     </ul>
     <p>The example below shows how to access route parameters in a Polymer 2
       based Web Component:</p>

--- a/src/documentation/location.js
+++ b/src/documentation/location.js
@@ -26,6 +26,29 @@ export class Location {
     this.pathname;
 
     /**
+     * (optional) The original pathname string in case if this location is a
+     * result of a redirect.
+     *
+     * E.g. with the routes config as below a navigation to `/u/12` produces a
+     * location with `pathname: '/user/12'` and `redirectFrom: '/u/12'`.
+     *
+     * ```javascript
+     * setRoutes([
+     *   {path: '/u/:id', redirect: '/user/:id'},
+     *   {path: '/user/:id', compoennt: 'x-user-view'},
+     * ]);
+     * ```
+     *
+     * See the **Redirects** section of the
+     * [live demos](#/classes/Vaadin.Router/demos/demo/index.html) for more
+     * details.
+     *
+     * @public
+     * @type {?string}
+     */
+    this.redirectFrom;
+
+    /**
      * (optional) The route object associated with `this` Web Component instance.
      *
      * This property is defined in the `location` objects that are passed as

--- a/src/documentation/location.js
+++ b/src/documentation/location.js
@@ -1,0 +1,72 @@
+/**
+ * This is a type declaration. It exists for build-time type checking and
+ * documentation purposes. It should not be used in any source code, and it
+ * certainly does not exist at the run time.
+ *
+ * `Location` describes the state of a router at a given point in time. It is
+ * available for your application code in several ways:
+ *  - as the `router.location` property
+ *  - as the `location` property set by Vaadin.Router on every view Web Component
+ *  - as the `location` argument passed by Vaadin.Router into view Web Component
+ *    lifecycle callbacks
+ *  - as the `event.detail.location` of the global Vaadin.Router events
+ *
+ * @memberof Vaadin.Router
+ * @summary Type declaration for the `router.location` property.
+ */
+export class Location {
+  constructor() {
+    /**
+     * The pathname as entered in the browser address bar
+     * (e.g. `/users/42/messages/12/edit`). It always starts with a `/` (slash).
+     *
+     * @public
+     * @type {!string}
+     */
+    this.pathname;
+
+    /**
+     * (optional) The route object associated with `this` Web Component instance.
+     *
+     * This property is defined in the `location` objects that are passed as
+     * parameters into Web Component lifecycle callbacks, and the `location`
+     * property set by Vaadin.Router on the Web Components.
+     *
+     * This property is undefined in the `location` objects that are available
+     * as `router.location`, and in the `location` that is included into the
+     * global router event details.
+     *
+     * @public
+     * @type {?Vaadin.Router.Route}
+     */
+    this.route;
+
+    /**
+     * A list of route objects that match the current pathname. This list has
+     * one element for each route that defines a parent layout, and then the
+     * element for the route that defines the view.
+     *
+     * See the **Getting Started** section of the
+     * [live demos](#/classes/Vaadin.Router/demos/demo/index.html) for more
+     * details on child routes and nested layouts.
+     *
+     * @public
+     * @type {!Array<!Vaadin.Router.Route>}
+     */
+    this.routes;
+
+    /**
+     * A bag of key-value pairs with parameters for the current location. Named
+     * parameters are available by name, unnamed ones - by index (e.g. for the
+     * `/users/:id` route the `:id` parameter is available as `location.params.id`).
+     *
+     * See the **Route Parameters** section of the
+     * [live demos](#/classes/Vaadin.Router/demos/demo/index.html) for more
+     * details.
+     *
+     * @public
+     * @type {!Object}
+     */
+    this.params;
+  }
+}

--- a/src/documentation/namespace.js
+++ b/src/documentation/namespace.js
@@ -1,0 +1,12 @@
+/**
+ * @namespace Vaadin
+ */
+window.Vaadin = {};
+
+/**
+ * @namespace Vaadin.Router
+ * @memberOf Vaadin
+ * @summary Type declaration for properties and method parameters of the
+ *   Vaadin.Router class.
+ */
+window.Vaadin.Router = {};

--- a/src/documentation/web-component-interface.js
+++ b/src/documentation/web-component-interface.js
@@ -140,6 +140,10 @@ export class WebComponentInterface {
    * If the router navigates to the same path twice in a row, in the second time the method is not called.
    * The WebComponent instance on which the callback has been invoked is available inside the callback through the `this` reference.
    *
+   * This callback is called asynchronously after the native
+   * [`connectedCallback()`](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reactions)
+   * defined by the Custom Elements spec.
+   *
    * @param context the context object with the following properties:
    *
    * | Property           | Description

--- a/src/documentation/web-component-interface.js
+++ b/src/documentation/web-component-interface.js
@@ -156,9 +156,6 @@ export class WebComponentInterface {
    */
   onAfterEnter(context) {
     // user implementation example:
-    return new Promise(resolve => {
-      sendVisitStatistics();
-      resolve();
-    });
+    sendVisitStatistics();
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -29,7 +29,7 @@ function createLocation({pathname = '', chain = [], params = {}, from}, route) {
   return {
     pathname,
     routes: chain.map(item => item.route),
-    route: (!route && chain.length && chain[chain.length - 1]) || route,
+    route: (!route && chain.length && chain[chain.length - 1].route) || route,
     params,
     redirectFrom: from,
   };

--- a/src/router.js
+++ b/src/router.js
@@ -351,37 +351,48 @@ export class Router extends Resolver {
   render(pathnameOrContext, shouldUpdateHistory) {
     const renderId = ++this.__lastStartedRenderId;
     const pathname = pathnameOrContext.pathname || pathnameOrContext;
+
+    // Find the first route that resolves to a non-empty result
     this.ready = this.resolve(pathnameOrContext)
-      .then(originalContext => this.__fullyResolveChain(originalContext, originalContext))
+
+      // Process the result of this.resolve() and handle all special commands:
+      // (redirect / prevent / component). If the result is a 'component',
+      // then go deeper and build the entire chain of nested components matching
+      // the pathname. Also call all 'on before' callbacks along the way.
+      .then(context => this.__fullyResolveChain(context))
+
       .then(context => {
         if (renderId === this.__lastStartedRenderId) {
-          if (shouldUpdateHistory) {
-            this.__updateBrowserHistory(context.result.route.pathname, context.from);
+          const previousContext = this.__previousContext;
+
+          // Check if the render was prevented and make an early return in that case
+          if (context === previousContext) {
+            return this.__outlet;
           }
 
-          const previousContext = this.__previousContext;
-          if (context !== previousContext) {
-            return this.__runOnAfterLeaveCallbacks(context, previousContext)
-              .then(() => this.__addAppearingContent(context, previousContext))
-              .then(() => this.__runOnAfterEnterCallbacks(context))
-              .then(() => context);
+          if (shouldUpdateHistory) {
+            this.__updateBrowserHistory(context.pathname, context.from);
           }
-          return Promise.resolve(context);
+
+          this.__runOnAfterLeaveCallbacks(context, previousContext);
+          this.__addAppearingContent(context, previousContext);
+          this.__runOnAfterEnterCallbacks(context);
+
+          return this.__animateIfNeeded(context)
+            .then(() => {
+              if (renderId === this.__lastStartedRenderId) {
+                // If there is another render pass started after this one,
+                // the 'disappearing content' would be removed when the other
+                // render pass calls `this.__addAppearingContent()`
+                this.__removeDisappearingContent();
+
+                this.__previousContext = context;
+                this.location = createLocation(context);
+                fireRouterEvent('location-changed', {router: this, location: this.location});
+                return this.__outlet;
+              }
+            });
         }
-      })
-      .then(context => {
-        if (renderId === this.__lastStartedRenderId) {
-          return this.__animateIfNeeded(context);
-        }
-      })
-      .then(context => {
-        if (renderId === this.__lastStartedRenderId) {
-          this.__removeDisappearingContent();
-        }
-        this.__previousContext = context;
-        this.location = createLocation(context);
-        fireRouterEvent('location-changed', {router: this, location: this.location});
-        return this.__outlet;
       })
       .catch(error => {
         if (renderId === this.__lastStartedRenderId) {
@@ -397,7 +408,7 @@ export class Router extends Resolver {
     return this.ready;
   }
 
-  __fullyResolveChain(originalContext, currentContext) {
+  __fullyResolveChain(originalContext, currentContext = originalContext) {
     return this.__amendWithResolutionResult(currentContext)
       .then(amendedContext => {
         const initialContext = amendedContext !== currentContext ? amendedContext : originalContext;
@@ -441,7 +452,7 @@ export class Router extends Resolver {
       if (amendedContext === this.__previousContext || amendedContext === contextWithFullChain) {
         return amendedContext;
       }
-      return this.__fullyResolveChain(amendedContext, amendedContext);
+      return this.__fullyResolveChain(amendedContext);
     });
   }
 
@@ -576,43 +587,34 @@ export class Router extends Resolver {
   }
 
   __runOnAfterLeaveCallbacks(currentContext, targetContext) {
-    let promises = Promise.resolve();
+    if (!targetContext) {
+      return;
+    }
 
-    if (targetContext) {
-      const callbackContext = copyContextWithoutNext(currentContext);
+    const callbackContext = copyContextWithoutNext(currentContext);
 
-      // REVERSE iteration: from Z to A
-      for (let i = targetContext.chain.length - 1; i >= currentContext.__divergedChainIndex; i--) {
-        const currentComponent = targetContext.chain[i].element;
-        if (!currentComponent) {
-          continue;
-        }
-        promises = promises
-          .then(() => runCallbackIfPossible(currentComponent.onAfterLeave, callbackContext, currentComponent))
-          .then((result) => {
-            removeDomNodes(currentComponent.children);
-            return result;
-          })
-          .catch((error) => {
-            removeDomNodes(currentComponent.children);
-            throw error;
-          });
+    // REVERSE iteration: from Z to A
+    for (let i = targetContext.chain.length - 1; i >= currentContext.__divergedChainIndex; i--) {
+      const currentComponent = targetContext.chain[i].element;
+      if (!currentComponent) {
+        continue;
+      }
+      try {
+        runCallbackIfPossible(currentComponent.onAfterLeave, callbackContext, currentComponent);
+      } finally {
+        removeDomNodes(currentComponent.children);
       }
     }
-    return promises;
   }
 
   __runOnAfterEnterCallbacks(currentContext) {
-    let promises = Promise.resolve();
     const callbackContext = copyContextWithoutNext(currentContext);
 
     // forward iteration: from A to Z
     for (let i = currentContext.__divergedChainIndex; i < currentContext.chain.length; i++) {
       const currentComponent = currentContext.chain[i].element || {};
-      promises = promises
-        .then(() => runCallbackIfPossible(currentComponent.onAfterEnter, callbackContext, currentComponent));
+      runCallbackIfPossible(currentComponent.onAfterEnter, callbackContext, currentComponent);
     }
-    return promises;
   }
 
   __animateIfNeeded(context) {
@@ -642,7 +644,7 @@ export class Router extends Resolver {
       });
     }
 
-    return context;
+    return Promise.resolve(context);
   }
 
   /**

--- a/src/router.js
+++ b/src/router.js
@@ -48,11 +48,7 @@ function createRedirect(context, pathname) {
 
 function renderComponent(context, component) {
   const element = document.createElement(component);
-  const params = Object.assign({}, context.params);
-  element.route = {params, pathname: context.pathname};
-  if (context.from) {
-    element.route.redirectFrom = context.from;
-  }
+  element.location = createLocation(context);
   const index = context.chain.map(item => item.route).indexOf(context.route);
   context.chain[index].element = element;
   return element;

--- a/src/router.js
+++ b/src/router.js
@@ -25,13 +25,13 @@ function copyContextWithoutNext(context) {
   return copy;
 }
 
-function createLocation({pathname = '', chain = [], params = {}, from}, route) {
+function createLocation({pathname = '', chain = [], params = {}, redirectFrom}, route) {
   return {
     pathname,
     routes: chain.map(item => item.route),
     route: (!route && chain.length && chain[chain.length - 1].route) || route,
     params,
-    redirectFrom: from,
+    redirectFrom,
   };
 }
 
@@ -363,7 +363,7 @@ export class Router extends Resolver {
           }
 
           if (shouldUpdateHistory) {
-            this.__updateBrowserHistory(context.pathname, context.from);
+            this.__updateBrowserHistory(context.pathname, context.redirectFrom);
           }
 
           this.__runOnAfterLeaveCallbacks(context, previousContext);
@@ -502,7 +502,7 @@ export class Router extends Resolver {
 
     return this.resolve({
       pathname: Router.pathToRegexp.compile(redirectData.pathname)(redirectData.params),
-      from: redirectData.from,
+      redirectFrom: redirectData.from,
       __redirectCount: (counter || 0) + 1
     });
   }

--- a/src/router.js
+++ b/src/router.js
@@ -378,7 +378,7 @@ export class Router extends Resolver {
         }
         this.__previousContext = context;
         this.location = createLocation(context);
-        fireRouterEvent('route-changed', {router: this, params: context.params, pathname: context.pathname});
+        fireRouterEvent('location-changed', {router: this, location: this.location});
         return this.__outlet;
       })
       .catch(error => {

--- a/test/router/dynamic-redirect.spec.html
+++ b/test/router/dynamic-redirect.spec.html
@@ -66,7 +66,7 @@
 
         it('action that returns custom component activates route', async() => {
           router.setRoutes([
-            {path: '/', action: context => context.component('x-home-view')},
+            {path: '/', action: (context, commands) => commands.component('x-home-view')},
           ]);
 
           await router.render('/');
@@ -76,7 +76,7 @@
 
         it('action that returns redirect activates redirect route', async() => {
           router.setRoutes([
-            {path: '/', action: context => context.redirect('/a')},
+            {path: '/', action: (context, commands) => commands.redirect('/a')},
             {path: '/a', component: 'x-users-view'},
           ]);
 
@@ -88,8 +88,8 @@
 
         it('should be able to have multiple action redirects', async() => {
           router.setRoutes([
-            {path: '/', action: context => context.redirect('/u')},
-            {path: '/u', action: context => context.redirect('/users')},
+            {path: '/', action: (context, commands) => commands.redirect('/u')},
+            {path: '/u', action: (context, commands) => commands.redirect('/users')},
             {path: '/users', component: 'x-users-list'}
           ]);
 
@@ -101,9 +101,9 @@
 
         it('should fail on recursive action redirects', async() => {
           router.setRoutes([
-            {path: '/a', action: context => context.redirect('/b')},
-            {path: '/b', action: context => context.redirect('/c')},
-            {path: '/c', action: context => context.redirect('/a')},
+            {path: '/a', action: (context, commands) => commands.redirect('/b')},
+            {path: '/b', action: (context, commands) => commands.redirect('/c')},
+            {path: '/c', action: (context, commands) => commands.redirect('/a')},
           ]);
 
           const onError = sinon.spy();
@@ -118,7 +118,7 @@
           const replaceSpy = sinon.spy(window.history, 'replaceState');
 
           router.setRoutes([
-            {path: '/', action: context => context.redirect('/a')},
+            {path: '/', action: (context, commands) => commands.redirect('/a')},
             {path: '/a', component: 'x-users-view'},
           ]);
 

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -117,7 +117,7 @@
       });
 
       describe('onBeforeEnter', () => {
-        it('should be called with 2 arguments: [location, commands]', async() => {
+        it('should be called with 3 arguments: [location, commands, router]', async() => {
           const onBeforeEnter = sinon.spy();
           router.setRoutes([
             {path: '/', action: onBeforeEnterAction('x-home-view', onBeforeEnter)}
@@ -126,7 +126,7 @@
           await router.render('/');
 
           expect(onBeforeEnter).to.have.been.called.once;
-          expect(onBeforeEnter.args[0].length).to.equal(2);
+          expect(onBeforeEnter.args[0].length).to.equal(3);
 
           const location = onBeforeEnter.args[0][0];
           expect(location.pathname).to.equal('/');
@@ -135,8 +135,8 @@
           const commands = onBeforeEnter.args[0][1];
           expect(commands).to.be.an('object').that.is.not.null;
 
-          // const routerArg = onBeforeEnter.args[0][2];
-          // expect(routerArg).to.equal(router);
+          const routerArg = onBeforeEnter.args[0][2];
+          expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
@@ -288,7 +288,7 @@
       });
 
       describe('onBeforeLeave', () => {
-        it('should be called with 2 arguments: [location, commands]', async() => {
+        it('should be called with 3 arguments: [location, commands, router]', async() => {
           const onBeforeLeave = sinon.spy();
           router.setRoutes([
             {path: '/', action: onBeforeLeaveAction('x-home-view', onBeforeLeave)},
@@ -301,7 +301,7 @@
           await router.render('/users');
 
           expect(onBeforeLeave).to.have.been.called.once;
-          expect(onBeforeLeave.args[0].length).to.equal(2);
+          expect(onBeforeLeave.args[0].length).to.equal(3);
 
           const location = onBeforeLeave.args[0][0];
           expect(location.pathname).to.equal('/users');
@@ -310,8 +310,8 @@
           const commands = onBeforeLeave.args[0][1];
           expect(commands).to.be.an('object').that.is.not.null;
 
-          // const routerArg = onBeforeLeave.args[0][2];
-          // expect(routerArg).to.equal(router);
+          const routerArg = onBeforeLeave.args[0][2];
+          expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
@@ -436,7 +436,7 @@
       });
 
       describe('onAfterLeave', () => {
-        it('should be called with 1 argument: [location]', async() => {
+        it('should be called with 3 arguments: [location, commands, router]', async() => {
           const onAfterLeave = sinon.spy();
           router.setRoutes([
             {path: '/', action: onAfterLeaveAction('x-home-view', onAfterLeave)},
@@ -450,14 +450,20 @@
           await router.render('/users');
 
           expect(onAfterLeave).to.have.been.called.once;
-          expect(onAfterLeave.args[0].length).to.equal(1);
+          expect(onAfterLeave.args[0].length).to.equal(3);
 
           const location = onAfterLeave.args[0][0];
           expect(location.pathname).to.equal('/users');
           expect(location.route.path).to.equal('/users');
 
-          // const routerArg = onAfterLeave.args[0][1];
-          // expect(routerArg).to.equal(router);
+          const commands = onAfterLeave.args[0][1];
+          expect(commands).to.be.an('object').that.is.not.null;
+          expect(commands.prevent).to.not.be.defined;
+          expect(commands.redirect).to.not.be.defined;
+          expect(commands.component).to.not.be.defined;
+
+          const routerArg = onAfterLeave.args[0][2];
+          expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
@@ -511,7 +517,7 @@
       });
 
       describe('onAfterEnter', () => {
-        it('should be called with 1 argument: [location]', async() => {
+        it('should be called with 3 argument: [location, commands, router]', async() => {
           const onAfterEnter = sinon.spy();
           router.setRoutes([
             {path: '/', action: onAfterEnterAction('x-home-view', onAfterEnter)}
@@ -520,14 +526,20 @@
           await router.render('/');
 
           expect(onAfterEnter).to.have.been.called.once;
-          expect(onAfterEnter.args[0].length).to.equal(1);
+          expect(onAfterEnter.args[0].length).to.equal(3);
 
           const location = onAfterEnter.args[0][0];
           expect(location.pathname).to.equal('/');
           expect(location.route.path).to.equal('/');
 
-          // const routerArg = onAfterEnter.args[0][2];
-          // expect(routerArg).to.equal(router);
+          const commands = onAfterEnter.args[0][1];
+          expect(commands).to.be.an('object').that.is.not.null;
+          expect(commands.prevent).to.not.be.defined;
+          expect(commands.redirect).to.not.be.defined;
+          expect(commands.component).to.not.be.defined;
+
+          const routerArg = onAfterEnter.args[0][2];
+          expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -1318,8 +1318,24 @@
           expect(onError.args[0].length).to.equal(1);
 
           const event = onError.args[0][0];
-          expect(event.detail.error).to.be.an('error');
           expect(event.detail.router).to.equal(router);
+        });
+
+        it('should contain the failed pathname as `event.detail.pathname`', async() => {
+          router.setRoutes([
+            {path: '/', component: 'x-home-view'},
+          ]);
+
+          const onError = sinon.spy();
+          window.addEventListener('vaadin-router-error', onError);
+          await router.render('/non-existent').catch(() => {});
+          window.removeEventListener('vaadin-router-error', onError);
+
+          expect(onError).to.have.been.called.once;
+          expect(onError.args[0].length).to.equal(1);
+
+          const event = onError.args[0][0];
+          expect(event.detail.pathname).to.equal('/non-existent');
         });
       });
     });

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -117,7 +117,7 @@
       });
 
       describe('onBeforeEnter', () => {
-        it('should be called with the router context as the only argument', async() => {
+        it('should be called with 2 arguments: [location, commands]', async() => {
           const onBeforeEnter = sinon.spy();
           router.setRoutes([
             {path: '/', action: onBeforeEnterAction('x-home-view', onBeforeEnter)}
@@ -126,15 +126,17 @@
           await router.render('/');
 
           expect(onBeforeEnter).to.have.been.called.once;
-          expect(onBeforeEnter.args[0].length).to.equal(1);
+          expect(onBeforeEnter.args[0].length).to.equal(2);
 
-          const context = onBeforeEnter.args[0][0];
-          expect(context.pathname).to.equal('/');
-          expect(context.route.path).to.equal('/');
-          expect(context.cancel).to.be.a('function');
-          expect(context.redirect).to.be.a('function');
-          expect(context.component).to.be.an('undefined');
-          expect(context.next).to.be.an('undefined');
+          const location = onBeforeEnter.args[0][0];
+          expect(location.pathname).to.equal('/');
+          expect(location.route.path).to.equal('/');
+
+          const commands = onBeforeEnter.args[0][1];
+          expect(commands).to.be.an('object').that.is.not.null;
+
+          // const routerArg = onBeforeEnter.args[0][2];
+          // expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
@@ -151,9 +153,9 @@
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });
 
-        it('should be able to return a `cancel` result to prevent navigation', async() => {
+        it('should be able to return a `prevent` command to prevent navigation', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('whatever', context => context.cancel())},
+            {path: '/', action: onBeforeEnterAction('whatever', (location, commands) => commands.prevent())},
             {path: '/users', component: 'x-users-list'}
           ]);
 
@@ -164,9 +166,9 @@
           verifyActiveRoutes(router, ['/users']);
         });
 
-        it('should be able to return a `redirect` result to redirect navigation', async() => {
+        it('should be able to return a `redirect` command to redirect navigation', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('whatever', context => context.redirect('/users'))},
+            {path: '/', action: onBeforeEnterAction('whatever', (location, commands) => commands.redirect('/users'))},
             {path: '/users', component: 'x-users-list'}
           ]);
 
@@ -178,8 +180,8 @@
 
         it('should be able to have multiple redirects', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('x-redirect-component', context => context.redirect('/u'))},
-            {path: '/u', action: onBeforeEnterAction('x-redirect-component', context => context.redirect('/users'))},
+            {path: '/', action: onBeforeEnterAction('x-redirect-component', (location, commands) => commands.redirect('/u'))},
+            {path: '/u', action: onBeforeEnterAction('x-redirect-component', (location, commands) => commands.redirect('/users'))},
             {path: '/users', component: 'x-users-list'}
           ]);
 
@@ -191,9 +193,9 @@
 
         it('should fail on recursive redirects', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeEnterAction('x-redirect-component', context => context.redirect('/u'))},
-            {path: '/u', action: onBeforeEnterAction('x-redirect-component', context => context.redirect('/users'))},
-            {path: '/users', action: onBeforeEnterAction('x-redirect-component', context => context.redirect('/'))}
+            {path: '/', action: onBeforeEnterAction('x-redirect-component', (location, commands) => commands.redirect('/u'))},
+            {path: '/u', action: onBeforeEnterAction('x-redirect-component', (location, commands) => commands.redirect('/users'))},
+            {path: '/users', action: onBeforeEnterAction('x-redirect-component', (location, commands) => commands.redirect('/'))}
           ]);
 
           const onError = sinon.spy();
@@ -203,7 +205,7 @@
           expect(onError).to.have.been.called.once;
         });
 
-        it('should ignore any other return value than `cancel` or `redirect`', async() => {
+        it('should ignore any other return value than `prevent` or `redirect`', async() => {
           const values = [
             true,
             false,
@@ -270,8 +272,8 @@
             connectedCallback() {
               counter++;
             }
-            onBeforeLeave(context) {
-              return context.cancel();
+            onBeforeLeave(location, commands) {
+              return commands.prevent();
             }
           });
           router.setRoutes([
@@ -286,7 +288,7 @@
       });
 
       describe('onBeforeLeave', () => {
-        it('should be called with the router context as the only argument', async() => {
+        it('should be called with 2 arguments: [location, commands]', async() => {
           const onBeforeLeave = sinon.spy();
           router.setRoutes([
             {path: '/', action: onBeforeLeaveAction('x-home-view', onBeforeLeave)},
@@ -299,15 +301,17 @@
           await router.render('/users');
 
           expect(onBeforeLeave).to.have.been.called.once;
-          expect(onBeforeLeave.args[0].length).to.equal(1);
+          expect(onBeforeLeave.args[0].length).to.equal(2);
 
-          const context = onBeforeLeave.args[0][0];
-          expect(context.pathname).to.equal('/users');
-          expect(context.route.path).to.equal('/users');
-          expect(context.cancel).to.be.a('function');
-          expect(context.redirect).to.be.an('undefined');
-          expect(context.component).to.be.an('undefined');
-          expect(context.next).to.be.an('undefined');
+          const location = onBeforeLeave.args[0][0];
+          expect(location.pathname).to.equal('/users');
+          expect(location.route.path).to.equal('/users');
+
+          const commands = onBeforeLeave.args[0][1];
+          expect(commands).to.be.an('object').that.is.not.null;
+
+          // const routerArg = onBeforeLeave.args[0][2];
+          // expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
@@ -328,9 +332,9 @@
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
 
-        it('should be able to return a `cancel` result to prevent navigation', async() => {
+        it('should be able to return a `prevent` command to prevent navigation', async() => {
           router.setRoutes([
-            {path: '/', action: onBeforeLeaveAction('x-home-view', context => context.cancel())},
+            {path: '/', action: onBeforeLeaveAction('x-home-view', (location, commands) => commands.prevent())},
             {path: '/users', component: 'x-users-list'},
           ]);
 
@@ -341,7 +345,7 @@
           verifyActiveRoutes(router, ['/']);
         });
 
-        it('should ignore any other return value than `cancel`', async() => {
+        it('should ignore any other return value than `prevent`', async() => {
           const values = [
             true,
             false,
@@ -416,8 +420,8 @@
             }
           });
           customElements.define('x-disallowed-view', class extends HTMLElement {
-            onBeforeEnter(context) {
-              return context.cancel();
+            onBeforeEnter(location, commands) {
+              return commands.prevent();
             }
           });
           router.setRoutes([
@@ -432,7 +436,7 @@
       });
 
       describe('onAfterLeave', () => {
-        it('should be called with the router context as the only argument', async() => {
+        it('should be called with 1 argument: [location]', async() => {
           const onAfterLeave = sinon.spy();
           router.setRoutes([
             {path: '/', action: onAfterLeaveAction('x-home-view', onAfterLeave)},
@@ -448,13 +452,12 @@
           expect(onAfterLeave).to.have.been.called.once;
           expect(onAfterLeave.args[0].length).to.equal(1);
 
-          const context = onAfterLeave.args[0][0];
-          expect(context.pathname).to.equal('/users');
-          expect(context.route.path).to.equal('/users');
-          expect(context.cancel).to.be.an('undefined');
-          expect(context.redirect).to.be.an('undefined');
-          expect(context.component).to.be.an('undefined');
-          expect(context.next).to.be.an('undefined');
+          const location = onAfterLeave.args[0][0];
+          expect(location.pathname).to.equal('/users');
+          expect(location.route.path).to.equal('/users');
+
+          // const routerArg = onAfterLeave.args[0][1];
+          // expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-users-list/i);
         });
@@ -508,7 +511,7 @@
       });
 
       describe('onAfterEnter', () => {
-        it('should be called with the router context as the only argument', async() => {
+        it('should be called with 1 argument: [location]', async() => {
           const onAfterEnter = sinon.spy();
           router.setRoutes([
             {path: '/', action: onAfterEnterAction('x-home-view', onAfterEnter)}
@@ -519,13 +522,12 @@
           expect(onAfterEnter).to.have.been.called.once;
           expect(onAfterEnter.args[0].length).to.equal(1);
 
-          const context = onAfterEnter.args[0][0];
-          expect(context.pathname).to.equal('/');
-          expect(context.route.path).to.equal('/');
-          expect(context.cancel).to.be.an('undefined');
-          expect(context.redirect).to.be.an('undefined');
-          expect(context.component).to.be.an('undefined');
-          expect(context.next).to.be.an('undefined');
+          const location = onAfterEnter.args[0][0];
+          expect(location.pathname).to.equal('/');
+          expect(location.route.path).to.equal('/');
+
+          // const routerArg = onAfterEnter.args[0][2];
+          // expect(routerArg).to.equal(router);
 
           expect(outlet.children[0].tagName).to.match(/x-home-view/i);
         });

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -44,9 +44,9 @@
 
     let callbacksLog = [];
 
-    const elementWithAllLifecycleCallbacks = elementName => context => {
+    const elementWithAllLifecycleCallbacks = elementName => (context, commands) => {
       callbacksLog.push(`${elementName}.action`);
-      const component = context.component('x-spy');
+      const component = commands.component('x-spy');
       component.name = elementName;
       return component;
     };

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -1190,16 +1190,16 @@
         });
       });
 
-      describe('the global `vaadin-router-route-changed` event', () => {
+      describe('the global `vaadin-router-location-changed` event', () => {
         it('should be triggered after a completed navigation', async() => {
           router.setRoutes([
             {path: '/', component: 'x-home-view'},
           ]);
 
           const onRouteChanged = sinon.spy();
-          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.addEventListener('vaadin-router-location-changed', onRouteChanged);
           await router.render('/');
-          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.removeEventListener('vaadin-router-location-changed', onRouteChanged);
 
           expect(onRouteChanged).to.have.been.called.once;
         });
@@ -1211,48 +1211,31 @@
           ]);
 
           const onRouteChanged = sinon.spy();
-          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.addEventListener('vaadin-router-location-changed', onRouteChanged);
           await Promise.all([
             router.render('/'),
             router.render('/admin')
           ]);
-          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.removeEventListener('vaadin-router-location-changed', onRouteChanged);
 
           expect(onRouteChanged).to.have.been.called.once;
         });
 
-        it('should contain the new path as `event.detail.pathname`', async() => {
+        it('should contain the new location as `event.detail.location`', async() => {
           router.setRoutes([
             {path: '/admin', component: 'x-admin-view'},
           ]);
 
           const onRouteChanged = sinon.spy();
-          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.addEventListener('vaadin-router-location-changed', onRouteChanged);
           await router.render('/admin');
-          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.removeEventListener('vaadin-router-location-changed', onRouteChanged);
 
           expect(onRouteChanged).to.have.been.called.once;
           expect(onRouteChanged.args[0].length).to.equal(1);
 
           const event = onRouteChanged.args[0][0];
-          expect(event.detail.pathname).to.equal('/admin');
-        });
-
-        it('should contain the route params as `event.detail.params`', async() => {
-          router.setRoutes([
-            {path: '/users/:user', component: 'x-users-view'},
-          ]);
-
-          const onRouteChanged = sinon.spy();
-          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
-          await router.render('/users/42');
-          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
-
-          expect(onRouteChanged).to.have.been.called.once;
-          expect(onRouteChanged.args[0].length).to.equal(1);
-
-          const event = onRouteChanged.args[0][0];
-          expect(event.detail.params).to.deep.equal({user: '42'});
+          expect(event.detail.location).to.equal(router.location);
         });
 
         it('should contain the router instance as `event.detail.router`', async() => {
@@ -1261,9 +1244,9 @@
           ]);
 
           const onRouteChanged = sinon.spy();
-          window.addEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.addEventListener('vaadin-router-location-changed', onRouteChanged);
           await router.render('/admin');
-          window.removeEventListener('vaadin-router-route-changed', onRouteChanged);
+          window.removeEventListener('vaadin-router-location-changed', onRouteChanged);
 
           expect(onRouteChanged).to.have.been.called.once;
           expect(onRouteChanged.args[0].length).to.equal(1);

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -51,10 +51,10 @@
       return component;
     };
 
-    const elementWithUserParameter = () => context => {
+    const elementWithUserParameter = () => (context, commands) => {
       const elementName = `x-user-${context.params.user}`;
       callbacksLog.push(`${elementName}.action`);
-      const component = context.component('x-spy');
+      const component = commands.component('x-spy');
       if (!component.name) {
         component.name = elementName;
       }

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -505,40 +505,6 @@
             verifyActiveRoutes(router, ['/users']);
           }
         });
-
-        it('should support returning a promise (and continue the resolve pass after the promise resolves)', async() => {
-          router.setRoutes([
-            {path: '/a', action: onAfterLeaveAction(
-              'x-spy',
-              function() {
-                callbacksLog.push('a.onAfterLeave');
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    callbacksLog.push('a.onAfterLeave.promise');
-                    resolve();
-                  }, 100);
-                });
-              },
-              'a')},
-            {path: '/b', action: elementWithAllLifecycleCallbacks('b')},
-          ]);
-
-          await router.render('/').catch(() => {});
-          await router.render('/a');
-          callbacksLog = [];
-          await router.render('/b');
-
-          expect(callbacksLog).to.deep.equal([
-            'b.action',
-            'a.onBeforeLeave',
-            'b.onBeforeEnter',
-            'a.onAfterLeave',
-            'a.onAfterLeave.promise',
-            'b.connectedCallback',
-            'b.onAfterEnter',
-            'a.disconnectedCallback',
-          ]);
-        });
       });
 
       describe('onAfterEnter', () => {
@@ -605,39 +571,6 @@
             expect(outlet.children[0].tagName).to.match(/x-users-list/i);
             verifyActiveRoutes(router, ['/users']);
           }
-        });
-
-        it('should support returning a promise (and continue the resolve pass after the promise resolves)', async() => {
-          router.setRoutes([
-            {path: '/a', action: elementWithAllLifecycleCallbacks('a')},
-            {path: '/b', action: onAfterEnterAction(
-              'x-spy',
-              function() {
-                callbacksLog.push('b.onAfterEnter');
-                return new Promise(resolve => {
-                  setTimeout(() => {
-                    callbacksLog.push('b.onAfterEnter.promise');
-                    resolve();
-                  }, 100);
-                });
-              },
-              'b')},
-          ]);
-
-          await router.render('/').catch(() => {});
-          await router.render('/a');
-          callbacksLog = [];
-          await router.render('/b');
-
-          verifyCallbacks([
-            'a.onBeforeLeave',
-            'b.onBeforeEnter',
-            'a.onAfterLeave',
-            'b.connectedCallback',
-            'b.onAfterEnter',
-            'b.onAfterEnter.promise',
-            'a.disconnectedCallback',
-          ]);
         });
       });
 

--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -90,8 +90,8 @@
       it('when action returns a component result, it is rendered the same way as if it was a component property', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [
-            {path: '/b', action: context => context.component('x-b'), children: [
-              {path: '/c', action: context => context.component('x-c')}
+            {path: '/b', action: (context, commands) => commands.component('x-b'), children: [
+              {path: '/c', action: (context, commands) => commands.component('x-c')}
             ]}
           ]},
         ]);
@@ -171,9 +171,14 @@
       it('action with redirect result amends previous path', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [
-            {path: '/b', action: context => context.redirect('/d/e'), component: 'x-b', children: [
-              {path: '/c', component: 'x-c'}
-            ]}
+            {
+              path: '/b',
+              action: (context, commands) => commands.redirect('/d/e'),
+              component: 'x-b',
+              children: [
+                {path: '/c', component: 'x-c'}
+              ]
+            }
           ]},
           {path: '/d', component: 'x-d', children: [
             {path: '/e', component: 'x-e'}

--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -189,7 +189,7 @@
       it('child layout: onBeforeEnter with redirect result amends previous path', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [
-            {path: '/b', action: onBeforeEnterAction('x-b', context => context.redirect('/d/e')), children: [
+            {path: '/b', action: onBeforeEnterAction('x-b', (location, commands) => commands.redirect('/d/e')), children: [
               {path: '/c', component: 'x-c'}
             ]}
           ]},
@@ -211,7 +211,7 @@
               {path: '/c', component: 'x-c'}
             ]}
           ]},
-          {path: '/d', action: onBeforeEnterAction('x-d', context => context.cancel()), children: [
+          {path: '/d', action: onBeforeEnterAction('x-d', (location, commands) => commands.prevent()), children: [
             {path: '/e', component: 'x-e'}
           ]}
         ]);
@@ -226,7 +226,7 @@
       it('child layout: onBeforeLeave with cancel result aborts current resolution', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [
-            {path: '/b', action: onBeforeLeaveAction('x-b', context => context.cancel()), children: [
+            {path: '/b', action: onBeforeLeaveAction('x-b', (location, commands) => commands.prevent()), children: [
               {path: '/c', component: 'x-c'}
             ]}
           ]},

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -426,7 +426,7 @@
           });
         });
 
-        describe('router.activeRoutes', () => {
+        describe('router.location', () => {
           let router;
           beforeEach(() => {
             router = new Vaadin.Router(outlet);
@@ -436,26 +436,76 @@
             router.unsubscribe();
           });
 
-          it('should be an array', () => {
-            expect(router).to.have.property('activeRoutes')
-              .that.is.an('array');
+          it('should be an object', () => {
+            expect(router).to.have.property('location')
+              .that.is.an('object');
           });
 
-          it('should be an empty array initially', () => {
-            expect(router.activeRoutes).to.deep.equal([]);
+          it('should initially have non-null pathname, routes and params properties', () => {
+            expect(router.location).to.have.property('pathname')
+              .that.is.a('string');
+            expect(router.location).to.have.property('routes')
+              .that.is.deep.equal([]);
+            expect(router.location).to.have.property('params')
+              .that.is.deep.equal({});
           });
 
-          it('should contain the routes chain of the last completed render pass (single route)', async() => {
+          it('should contain the pathname from the last completed render pass', async() => {
+            router.setRoutes([
+              {path: '/', component: 'x-root'},
+              {path: '/a/b/c', component: 'x-a'}
+            ]);
+
+            await router.render('/');
+            await router.render('/a/b/c');
+
+            expect(router.location.pathname).to.equal('/a/b/c');
+          });
+
+          it('should contain the pathname from the last completed render pass (with params)', async() => {
+            router.setRoutes([
+              {path: '/a/b/:c', component: 'x-a'}
+            ]);
+
+            await router.render('/a/b/42');
+
+            expect(router.location.pathname).to.equal('/a/b/42');
+          });
+
+          it('should contain the final and the original pathnames from the last completed render pass (redirected)', async() => {
+            router.setRoutes([
+              {path: '/a', redirect: '/c'},
+              {path: '/c', component: 'x-a'}
+            ]);
+
+            await router.render('/a');
+
+            expect(router.location.pathname).to.equal('/c');
+            expect(router.location.redirectFrom).to.equal('/a');
+          });
+
+          it('should contain the pathname after a failed render', async() => {
+            router.setRoutes([
+              {path: '/a', component: 'x-a'}
+            ]);
+
+            await router.render('/a');
+            await router.render('/non-existent-path').catch(() => {});
+
+            expect(router.location.pathname).to.equal('/non-existent-path');
+          });
+
+          it('should contain the routes chain from the last completed render pass (single route)', async() => {
             const route = {path: '/', component: 'x-home-view'};
             router.setRoutes(route);
 
             await router.ready;
 
-            expect(router.activeRoutes).to.have.lengthOf(1);
-            expect(router.activeRoutes[0]).to.equal(route);
+            expect(router.location.routes).to.have.lengthOf(1);
+            expect(router.location.routes[0]).to.equal(route);
           });
 
-          it('should contain the routes chain of the last completed render pass (multiple routes)', async() => {
+          it('should contain the routes chain from the last completed render pass (multiple routes)', async() => {
             const routeC = {path: '/c', component: 'x-c'};
             const routeB = {path: '/b', component: 'x-b', children: [routeC]};
             const routeA = {path: '/a', component: 'x-a', children: [routeB]};
@@ -463,20 +513,54 @@
             router.setRoutes(routeA);
             await router.render('/a/b/c');
 
-            expect(router.activeRoutes).to.have.lengthOf(3);
-            expect(router.activeRoutes[0]).to.equal(routeA);
-            expect(router.activeRoutes[1]).to.equal(routeB);
-            expect(router.activeRoutes[2]).to.equal(routeC);
+            expect(router.location.routes).to.have.lengthOf(3);
+            expect(router.location.routes[0]).to.equal(routeA);
+            expect(router.location.routes[1]).to.equal(routeB);
+            expect(router.location.routes[2]).to.equal(routeC);
           });
 
-          it('should be an empty array after a failed render', async() => {
+          it('should contain an empty routes chain array after a failed render', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'}
             ]);
             await router.render('/');
             await router.render('/non-existent').catch(() => {});
 
-            expect(router.activeRoutes).to.deep.equal([]);
+            expect(router.location.routes).to.deep.equal([]);
+          });
+
+          it('should contain the parameters from the last completed render pass', async() => {
+            router.setRoutes([
+              {path: '/a/:b', component: 'x-a'},
+              {path: '/:a/:b', component: 'x-any'},
+            ]);
+
+            await router.render('/any/thing');
+            await router.render('/a/42');
+
+            expect(router.location.params).to.deep.equal({b: '42'});
+          });
+
+          it('should contain the parameters from the last completed render pass (redirected)', async() => {
+            router.setRoutes([
+              {path: '/a/:id', redirect: '/b/:id'},
+              {path: '/b/:id', component: 'x-b'}
+            ]);
+
+            await router.render('/a/42');
+
+            expect(router.location.params).to.deep.equal({id: '42'});
+          });
+
+          it('should contain an empty parameters set after a failed render', async() => {
+            router.setRoutes([
+              {path: '/a/:id', component: 'x-a'}
+            ]);
+
+            await router.render('/a/42');
+            await router.render('/non-existent-path').catch(() => {});
+
+            expect(router.location.params).to.deep.equal({});
           });
         });
 

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -279,7 +279,7 @@
             const firstResult = await spy.returnValues[0];
             expect(firstResult.result).to.deep.equal(result);
 
-            expect(spy.secondCall.args[0].from).to.equal(from);
+            expect(spy.secondCall.args[0].redirectFrom).to.equal(from);
             expect(spy.secondCall.args[0].pathname).to.equal(pathname);
           });
 
@@ -1127,7 +1127,7 @@
             expect(outlet.children[0].tagName).to.match(/x-home-view/i);
           });
 
-          it('action with redirect has its context.from and redirect.from populated correctly', async() => {
+          it('action with redirect has its context.redirectFrom and redirect.from populated correctly', async() => {
             const from = '/a/b/c';
 
             router.setRoutes([
@@ -1141,7 +1141,7 @@
                 ]},
               ]},
               {path: '/d', component: 'x-home-view', action: context => {
-                expect(context.from).to.be.equal(from);
+                expect(context.redirectFrom).to.be.equal(from);
               }}
             ]);
 
@@ -1150,7 +1150,7 @@
             expect(outlet.children[0].tagName).to.match(/x-home-view/i);
           });
 
-          it('action with redirect gets double slashes removed from its context.from and redirect.from', async() => {
+          it('action with redirect gets double slashes removed from its context.redirectFrom and redirect.from', async() => {
             let from = '';
             router.setRoutes([
               {path: '/', children: [
@@ -1159,7 +1159,7 @@
                 ]},
               ]},
               {path: '/d', component: 'x-home-view', action: context => {
-                from = context.from;
+                from = context.redirectFrom;
               }}
             ]);
 

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -333,14 +333,14 @@
             expect(replaceSpy).to.be.calledOnce;
           });
 
-          it('should set the `route.redirectFrom` property on the route component in case of redirect', async() => {
+          it('should set the `location.redirectFrom` property on the route component in case of redirect', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/people', redirect: '/users'},
               {path: '/users', component: 'x-users-view'},
             ]);
             await router.render('/people');
-            expect(outlet.children[0]).to.have.deep.property('route.redirectFrom', '/people');
+            expect(outlet.children[0]).to.have.deep.property('location.redirectFrom', '/people');
           });
         });
 
@@ -718,7 +718,7 @@
             router.unsubscribe();
           });
 
-          it('should bind named parameters to `route.params` property using string keys', async() => {
+          it('should bind named parameters to `location.params` property using string keys', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/:user', component: 'x-user-profile'}
@@ -726,13 +726,13 @@
             router.render('/foo');
             await router.ready.then((outlet) => {
               const elem = outlet.children[0];
-              expect(elem.route).to.be.object;
-              expect(elem.route.params).to.be.object;
-              expect(elem.route.params.user).to.equal('foo');
+              expect(elem.location).to.be.object;
+              expect(elem.location.params).to.be.object;
+              expect(elem.location.params.user).to.equal('foo');
             });
           });
 
-          it('should bind unnamed parameters to `route.params` property using numeric indexes', async() => {
+          it('should bind unnamed parameters to `location.params` property using numeric indexes', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/(user[s]?)/:id', component: 'x-users-view'},
@@ -740,13 +740,13 @@
             router.render('/users/1');
             await router.ready.then((outlet) => {
               const elem = outlet.children[0];
-              expect(elem.route).to.be.object;
-              expect(elem.route.params).to.be.object;
-              expect(elem.route.params[0]).to.equal('users');
+              expect(elem.location).to.be.object;
+              expect(elem.location.params).to.be.object;
+              expect(elem.location.params[0]).to.equal('users');
             });
           });
 
-          it('should bind named custom parameters to `route.params` property using string keys', async() => {
+          it('should bind named custom parameters to `location.params` property using string keys', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/image-:size(\\d+)px', component: 'x-image-view'},
@@ -754,13 +754,13 @@
             router.render('/image-15px');
             await router.ready.then((outlet) => {
               const elem = outlet.children[0];
-              expect(elem.route).to.be.object;
-              expect(elem.route.params).to.be.object;
-              expect(elem.route.params.size).to.equal('15');
+              expect(elem.location).to.be.object;
+              expect(elem.location.params).to.be.object;
+              expect(elem.location.params.size).to.equal('15');
             });
           });
 
-          it('should bind named segments to the `route.params` property using string keys', async() => {
+          it('should bind named segments to the `location.params` property using string keys', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/kb/:path+/:id', component: 'x-knowledge-base'},
@@ -768,21 +768,21 @@
             router.render('/kb/folder/nested/1');
             await router.ready.then((outlet) => {
               const elem = outlet.children[0];
-              expect(elem.route).to.be.object;
-              expect(elem.route.params).to.be.object;
-              expect(elem.route.params.path).to.deep.equal(['folder', 'nested']);
-              expect(elem.route.params.id).to.equal('1');
+              expect(elem.location).to.be.object;
+              expect(elem.location.params).to.be.object;
+              expect(elem.location.params.path).to.deep.equal(['folder', 'nested']);
+              expect(elem.location.params.id).to.equal('1');
             });
           });
 
-          it('should set the `route.pathname` property on the route component', async() => {
+          it('should set the `location.pathname` property on the route component', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
               {path: '/admin', component: 'x-admin-view'},
               {path: '(.*)', component: 'x-not-found-view'},
             ]);
             await router.render('/non-existent/path');
-            expect(outlet.children[0]).to.have.deep.property('route.pathname', '/non-existent/path');
+            expect(outlet.children[0]).to.have.deep.property('location.pathname', '/non-existent/path');
           });
 
           it('should keep route parameters when redirecting to different route', async() => {
@@ -794,8 +794,8 @@
             await router.render('/users/1');
             const elem = outlet.children[0];
             expect(elem.tagName).to.match(/x-users-view/i);
-            expect(elem.route.params).to.be.object;
-            expect(elem.route.params.id).to.equal('1');
+            expect(elem.location.params).to.be.object;
+            expect(elem.location.params.id).to.equal('1');
           });
 
           it('should create new component instance for the same route with different parameters', async() => {
@@ -807,15 +807,15 @@
             await router.render('/users/1');
             const elemOne = outlet.children[0];
             expect(elemOne.tagName).to.match(/x-users-view/i);
-            expect(elemOne.route.params).to.be.object;
-            expect(elemOne.route.params.id).to.equal('1');
+            expect(elemOne.location.params).to.be.object;
+            expect(elemOne.location.params.id).to.equal('1');
 
             await router.render('/users/2');
             const elemTwo = outlet.children[0];
             expect(elemTwo.tagName).to.match(/x-users-view/i);
             expect(elemTwo).to.not.equal(elemOne);
-            expect(elemTwo.route.params).to.be.object;
-            expect(elemTwo.route.params.id).to.equal('2');
+            expect(elemTwo.location.params).to.be.object;
+            expect(elemTwo.location.params.id).to.equal('2');
           });
         });
 
@@ -1044,8 +1044,8 @@
 
             const elem = outlet.children[0];
             expect(elem.tagName).to.match(/x-users-view/i);
-            expect(elem.route.params).to.be.object;
-            expect(elem.route.params.id).to.equal('1');
+            expect(elem.location.params).to.be.object;
+            expect(elem.location.params.id).to.equal('1');
           });
 
           it('action can render components by using the context method', async() => {
@@ -1057,8 +1057,8 @@
 
             const elem = outlet.children[0];
             expect(elem.tagName).to.match(/x-users-view/i);
-            expect(elem.route.params).to.be.object;
-            expect(elem.route.params.id).to.equal('1');
+            expect(elem.location.params).to.be.object;
+            expect(elem.location.params.id).to.equal('1');
           });
 
           it('redirect should be executed before component and stop it from loading', async() => {
@@ -1208,8 +1208,8 @@
 
             const elem = outlet.children[0];
             expect(elem.tagName).to.match(/x-user-profile/i);
-            expect(elem.route.params).to.be.object;
-            expect(elem.route.params.user).to.equal('2');
+            expect(elem.location.params).to.be.object;
+            expect(elem.location.params.user).to.equal('2');
           });
 
           it('should be able to return a promise', async() => {
@@ -1225,8 +1225,8 @@
 
             const elem = outlet.children[0];
             expect(elem.tagName).to.match(/x-user-profile/i);
-            expect(elem.route.params).to.be.object;
-            expect(elem.route.params.user).to.equal('2');
+            expect(elem.location.params).to.be.object;
+            expect(elem.location.params.user).to.equal('2');
           });
 
           it('should be able to override the route `children` property instead of returning a value', async() => {

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -436,9 +436,10 @@
             router.unsubscribe();
           });
 
-          it('should be an object', () => {
+          it('should be a non-null object', () => {
             expect(router).to.have.property('location')
-              .that.is.an('object');
+              .that.is.an('object')
+              .and.is.not.null;
           });
 
           it('should initially have non-null pathname, routes and params properties', () => {
@@ -527,6 +528,29 @@
             await router.render('/non-existent').catch(() => {});
 
             expect(router.location.routes).to.deep.equal([]);
+          });
+
+          it('should have a separate property for the last route of the routes chain', async() => {
+            const routeC = {path: '/c', component: 'x-c'};
+            const routeB = {path: '/b', component: 'x-b', children: [routeC]};
+            const routeA = {path: '/a', component: 'x-a', children: [routeB]};
+
+            router.setRoutes(routeA);
+            await router.render('/a/b/c');
+
+            expect(router.location.route).to.equal(routeC);
+          });
+
+          it('should have an `undefined` route property after a failed render', async() => {
+            const routeC = {path: '/c', component: 'x-c'};
+            const routeB = {path: '/b', component: 'x-b', children: [routeC]};
+            const routeA = {path: '/a', component: 'x-a', children: [routeB]};
+
+            router.setRoutes(routeA);
+            await router.render('/a/b/c');
+            await router.render('/non-existent').catch(() => {});
+
+            expect(router.location.route).to.not.be.defined;
           });
 
           it('should contain the parameters from the last completed render pass', async() => {

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -868,14 +868,17 @@
             await router.render('/');
 
             expect(action).to.have.been.called.once;
-            expect(action.args[0].length).to.equal(1);
+            expect(action.args[0].length).to.equal(2);
+
             const contextParam = action.args[0][0];
             expect(contextParam.pathname).to.equal('/');
             expect(contextParam.route.path).to.equal('/');
             expect(contextParam.route.component).to.equal('x-home-view');
-            expect(contextParam.cancel).to.be.an('undefined');
-            expect(contextParam.redirect).to.be.a('function');
-            expect(contextParam.component).to.be.a('function');
+
+            const commandsParam = action.args[0][1];
+            expect(commandsParam.prevent).to.be.an('undefined');
+            expect(commandsParam.redirect).to.be.a('function');
+            expect(commandsParam.component).to.be.a('function');
           });
 
           it('action.this points to the route that defines action', async() => {
@@ -979,9 +982,9 @@
             const children = sinon.spy();
 
             router.setRoutes([
-              {path: '/home', children, action: context => {
+              {path: '/home', children, action: (context, commands) => {
                 actionExecuted = true;
-                return context.redirect('/users');
+                return commands.redirect('/users');
               }},
               {path: '/users', component: 'x-users-view'},
             ]);
@@ -1033,7 +1036,7 @@
 
           it('action can redirect by using the context method', async() => {
             router.setRoutes([
-              {path: '/users/:id', action: context => context.redirect('/user/:id')},
+              {path: '/users/:id', action: (context, commands) => commands.redirect('/user/:id')},
               {path: '/user/:id', component: 'x-users-view'},
             ]);
 
@@ -1047,7 +1050,7 @@
 
           it('action can render components by using the context method', async() => {
             router.setRoutes([
-              {path: '/users/:id', action: context => context.component('x-users-view')},
+              {path: '/users/:id', action: (context, commands) => commands.component('x-users-view')},
             ]);
 
             await router.render('/users/1');
@@ -1116,7 +1119,7 @@
           it('context.redirect() should work when invoked without the `this` context', async() => {
             router.setRoutes([
               {path: '/', component: 'x-home-view'},
-              {path: '/a', action: ({redirect}) => redirect('/')}
+              {path: '/a', action: (context, commands) => commands.redirect('/')}
             ]);
 
             await router.render('/a');
@@ -1130,8 +1133,8 @@
             router.setRoutes([
               {path: '/a', children: [
                 {path: '/b', children: [
-                  {path: '/c', action: context => {
-                    const redirectObject = context.redirect('/d');
+                  {path: '/c', action: (context, commands) => {
+                    const redirectObject = commands.redirect('/d');
                     expect(redirectObject.redirect.from).to.be.equal(from);
                     return redirectObject;
                   }}
@@ -1152,7 +1155,7 @@
             router.setRoutes([
               {path: '/', children: [
                 {path: '', children: [
-                  {path: '/c', action: context => context.redirect('/d')}
+                  {path: '/c', action: (context, commands) => commands.redirect('/d')}
                 ]},
               ]},
               {path: '/d', component: 'x-home-view', action: context => {
@@ -1323,9 +1326,6 @@
             expect(context.pathname).to.equal('/users/1');
             expect(context.route.path).to.equal('/users');
             expect(context.next).to.be.an('undefined');
-            expect(context.cancel).to.be.an('undefined');
-            expect(context.redirect).to.be.an('undefined');
-            expect(context.component).to.be.an('undefined');
           });
 
           it('should be called on the route object (as `this`)', async() => {

--- a/test/router/test-utils.js
+++ b/test/router/test-utils.js
@@ -3,8 +3,8 @@ function verifyActiveRoutes(router, expectedSegments) {
 }
 
 function onBeforeLeaveAction(componentName, callback, name) {
-  return context => {
-    const component = context.component(componentName);
+  return (context, commands) => {
+    const component = commands.component(componentName);
     component.name = name;
     component.onBeforeLeave = callback;
     return component;
@@ -12,8 +12,8 @@ function onBeforeLeaveAction(componentName, callback, name) {
 }
 
 function onBeforeEnterAction(componentName, callback, name) {
-  return context => {
-    const component = context.component(componentName);
+  return (context, commands) => {
+    const component = commands.component(componentName);
     component.name = name;
     component.onBeforeEnter = callback;
     return component;
@@ -21,8 +21,8 @@ function onBeforeEnterAction(componentName, callback, name) {
 }
 
 function onAfterEnterAction(componentName, callback, name) {
-  return context => {
-    const component = context.component(componentName);
+  return (context, commands) => {
+    const component = commands.component(componentName);
     component.name = name;
     component.onAfterEnter = callback;
     return component;
@@ -30,8 +30,8 @@ function onAfterEnterAction(componentName, callback, name) {
 }
 
 function onAfterLeaveAction(componentName, callback, name) {
-  return context => {
-    const component = context.component(componentName);
+  return (context, commands) => {
+    const component = commands.component(componentName);
     component.name = name;
     component.onAfterLeave = callback;
     return component;


### PR DESCRIPTION
Use similar data structures across all public APIs that expose a similar set of properties:

 - custom route actions
 - lifecycle callbacks
 - global router events
 - the property set by Vaadin.Router on view Web Components
 - the router JS API (`router.location`)

Closes #209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/222)
<!-- Reviewable:end -->
