### PR TITLE
Fix parent layouts: update references to the unchanged elements

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -513,13 +513,14 @@ export class Router extends Resolver {
     this.__removeAppearingContent();
 
     // Find the deepest common parent between the last and the new component
-    // chains.
+    // chains. Update references for the unchanged elements in the new chain
     let deepestCommonParent = this.__outlet;
     for (let i = 0; i < context.__divergedChainIndex; i++) {
-      const unchangedComponent = previousContext && previousContext.chain[i].element;
-      if (unchangedComponent) {
-        if (unchangedComponent.parentNode === deepestCommonParent) {
-          deepestCommonParent = unchangedComponent;
+      const unchangedElement = previousContext && previousContext.chain[i].element;
+      if (unchangedElement) {
+        if (unchangedElement.parentNode === deepestCommonParent) {
+          context.chain[i].element = unchangedElement;
+          deepestCommonParent = unchangedElement;
         } else {
           break;
         }

--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -71,6 +71,30 @@
         checkOutlet(['x-a', 'x-b', 'x-c']);
       });
 
+      it('should preserve references to same DOM node and reuse it on subsequent renders', async() => {
+        router.setRoutes([
+          {path: '/a', component: 'x-a', children: [
+            {path: '/b', component: 'x-b'},
+            {path: '/c', component: 'x-c'},
+            {path: '/d', component: 'x-d'}
+          ]}
+        ]);
+
+        await router.render('/a/b');
+        const first = outlet.children[0];
+        expect(first.firstElementChild.tagName).to.match(/x-b/i);
+
+        await router.render('/a/c');
+        const second = outlet.children[0];
+        expect(second).to.equal(first);
+        expect(second.firstElementChild.tagName).to.match(/x-c/i);
+
+        await router.render('/a/d');
+        const third = outlet.children[0];
+        expect(third).to.equal(second);
+        expect(third.firstElementChild.tagName).to.match(/x-d/i);
+      });
+
       it('should remove nested route components when the parent route is navigated to', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [


### PR DESCRIPTION
Regression from #221 

Now we no longer use "early caching" but creating new DOM node before obtaining diverged index, so this fixes the references to the unchanged element in the new chain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/223)
<!-- Reviewable:end -->
