### PR TITLE
shorten the code in __animateIfNeeded

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -638,13 +638,7 @@ export class Router extends Resolver {
       promises.push(animate(to, enter));
     }
 
-    if (promises.length) {
-      return new Promise(resolve => {
-        Promise.all(promises).then(() => resolve(context));
-      });
-    }
-
-    return Promise.resolve(context);
+    return Promise.all(promises).then(() => context);
   }
 
   /**


### PR DESCRIPTION
`Promise.all([])` is a supported behavior (it immediately resolves with an `undefined` result). That is, checking that promises is not empty is redundant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/224)
<!-- Reviewable:end -->
