### PR TITLE
stop using a custom fork of vaadin-demo-helpers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
     "polymer": "^2.0.0",
-    "vaadin-demo-helpers": "vlukashov/vaadin-demo-helpers#feature/iframe-renderer"
+    "vaadin-demo-helpers": "^1.3.0"
   }
 }


### PR DESCRIPTION
The iframe-renderer and other features from the custom form got merged upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/233)
<!-- Reviewable:end -->
