### PR TITLE
Use 'latest' and 'latest-1' for SauceLabs platforms

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -6,8 +6,8 @@ module.exports = {
       // The list below is based on the browserslist config defined in package.json
       context.options.plugins.sauce.browsers = [
         // // last 2 Chrome major versions (desktop)
-        'Windows 10/chrome@66',
-        'Windows 10/chrome@67',
+        'Windows 10/chrome@latest',
+        'Windows 10/chrome@latest-1',
 
         // last 2 Android major versions (mobile Chrome)
         {
@@ -15,23 +15,23 @@ module.exports = {
           platformName: 'Android',
           platformVersion: '7.1',
           browserName: 'chrome',
-          browserVersion: '67'
+          browserVersion: 'latest'
         },
         {
           deviceName: 'Android Emulator',
           platformName: 'Android',
           platformVersion: '6.0',
           browserName: 'chrome',
-          browserVersion: '66'
+          browserVersion: 'latest-1'
         },
 
         // last 2 Firefox major versions (desktop)
-        'Windows 10/firefox@59',
-        'Windows 10/firefox@60',
+        'Windows 10/firefox@latest',
+        'Windows 10/firefox@latest-1',
 
         // last 2 Edge major versions (desktop)
-        'Windows 10/microsoftedge@16',
-        'Windows 10/microsoftedge@17',
+        'Windows 10/microsoftedge@latest',
+        'Windows 10/microsoftedge@latest-1',
 
         // last 2 Safari major versions (desktop)
         'macOS 10.13/safari@11.1',


### PR DESCRIPTION
From https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-BrowserVersion

> Default to Latest Version of Chrome or Firefox
> If you want to use the latest stable version of Google Chrome or Firefox that Sauce supports, you can use "version": "latest". You can also use "version": "latest-1" or "version": "latest-2", etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/240)
<!-- Reviewable:end -->
