### PR TITLE
fix an unstable test for animated transitions

### DIFF
--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -1444,7 +1444,7 @@
             await router.render('/animate');
 
             // FIXME(web-padawan): force IE11 to pick up mutations
-            if (/Trident/.test(navigator.userAgent)) {
+            if (/Trident/.test(navigator.userAgent) && data.length !== 4) {
               data = observer.takeRecords();
             }
 


### PR DESCRIPTION
in IE11 Mutation Observer is not very predictable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/263)
<!-- Reviewable:end -->
