### PR TITLE
pass the correct route params to lifecycle callbacks in child routes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -508,7 +508,7 @@ export class Router extends Resolver {
             }
             return nextChildContext && nextChildContext !== notFoundResult
               ? this.__fullyResolveChain(topOfTheChainContextAfterRedirects, nextChildContext)
-              : this.__amendWithOnBeforeCallbacks(topOfTheChainContextAfterRedirects);
+              : this.__amendWithOnBeforeCallbacks(contextAfterRedirects);
           });
       });
   }

--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -50,6 +50,7 @@
       const {
         verifyActiveRoutes,
         onBeforeEnterAction,
+        onAfterEnterAction,
         onBeforeLeaveAction,
         checkOutletContents
       } = VaadinTestNamespace;
@@ -232,6 +233,28 @@
 
         verifyActiveRoutes(router, ['/d', '/e']);
         checkOutlet(['x-d', 'x-e']);
+      });
+
+      it('child layout: onAfterEnter should receive correct route parameters', async() => {
+        const onAfterEnter = sinon.spy();
+        router.setRoutes([
+          {path: '/a', component: 'x-a', children: [
+            {path: '/b/:id', action: onAfterEnterAction('x-b', onAfterEnter)}
+          ]}
+        ]);
+
+        await router.render('/a/b/123');
+
+        expect(onAfterEnter).to.have.been.called.once;
+        expect(onAfterEnter.args[0].length).to.equal(3);
+
+        const location = onAfterEnter.args[0][0];
+        expect(location.pathname).to.equal('/a/b/123');
+        expect(location.route.path).to.equal('/b/:id');
+        expect(location.params).to.have.property('id', '123');
+
+        verifyActiveRoutes(router, ['/a', '/b/:id']);
+        checkOutlet(['x-a', 'x-b']);
       });
 
       it('child layout: onBeforeEnter with redirect result amends previous path', async() => {


### PR DESCRIPTION
Call lifecycle callbacks in the context of the deepest child route instead of calling them in the context of the top-most parent route. The parent context does not have route params, whereas the child context does.

Fixes #321

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/322)
<!-- Reviewable:end -->
