### PR TITLE
prevent rendering component

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -431,7 +431,7 @@ export class Router extends Resolver {
           const previousContext = this.__previousContext;
 
           // Check if the render was prevented and make an early return in that case
-          if (context === previousContext) {
+          if (previousContext && context && context.pathname === previousContext.pathname) {
             return this.location;
           }
 


### PR DESCRIPTION
If previous and current routes are the same there is no reasons to re render the component, seems this PR could resolve #311 too. 
In My case, web component constructed but never render anything if I click on the same route more than once. I am using Lit-element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/331)
<!-- Reviewable:end -->
