### PR TITLE
chore(package): restore using module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.0",
   "description": "Small and powerful client-side router for Web Components. Framework-agnostic.",
   "main": "dist/vaadin-router.js",
+  "module": "dist/vaadin-router.js",
   "repository": "vaadin/vaadin-router",
   "keywords": [
     "Vaadin",


### PR DESCRIPTION
The field was there initially, but it has been removed in #130. 
Recently there has been a request to put it back, e.g. to be compatible with @pikapkg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/336)
<!-- Reviewable:end -->
