### PR TITLE
test: update browser versions to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: 62.0
+  firefox: 66.0
   chrome: stable
 
 # limit the Travis 'build on push' feature to the master branch only

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -38,8 +38,8 @@ module.exports = {
         'macOS 10.12/safari@10.1',
 
         // last 2 iOS major versions (mobile Safari)
+        'iOS Simulator/iphone@12.0',
         'iOS Simulator/iphone@11.0',
-        'iOS Simulator/iphone@10.0',
 
         // Safari 9 on desktop and mobile
         'OS X 10.11/safari@9.0',


### PR DESCRIPTION
SauceLabs removed support for older Safari versions:

```
iOS Simulator iphone 11.0 Tests passed
Test run ended in failure: Misconfigured -- Unsupported OS/browser/version/device combo: OS: 'unspecified', Browser: 'iphone', Version: '10.0.', Device: 'iPhone Simulator'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/337)
<!-- Reviewable:end -->
