### PR TITLE
fix: add prepare script to allow usage via git directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "size-control": "bundlesize",
     "docs": "npm run build && npm run docs:analyze && gulp docs",
     "docs:analyze": "polymer analyze dist/vaadin-router.js src/documentation/*.js > analysis.json",
-    "browserslist": "browserslist && browserslist --coverage"
+    "browserslist": "browserslist && browserslist --coverage",
+    "prepare": "npm run build"
   },
   "bundlesize": [
     {


### PR DESCRIPTION
Interesting for me to use the typescript branch for example 🙂

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/367)
<!-- Reviewable:end -->
