### PR TITLE
feat(router): add purgeOutlet option

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -110,6 +110,7 @@ declare namespace Router {
 
   interface Options {
     baseUrl?: string;
+    purgeOutlet?: boolean;
   }
 
   interface NavigationTrigger {

--- a/src/router.js
+++ b/src/router.js
@@ -139,6 +139,9 @@ function getMatchedPath(chain) {
  *   * `baseUrl` — the initial value for [
  *     the `baseUrl` property
  *   ](#/classes/Router#property-baseUrl)
+ *   * `purgeOutlet` — wheather to purge and rebuild all nodes within the outlet
+ *     on navigation. Defaults to `false` and will retain common parent nodes
+ *     within outlet.
  *
  * The Router instance is automatically subscribed to navigation events
  * on `window`.
@@ -218,6 +221,7 @@ export class Router extends Resolver {
     this.location;
     this.location = createLocation({resolver: this});
 
+    this.__purgeOutlet = (options && options.purgeOutlet) || false;
     this.__lastStartedRenderId = 0;
     this.__navigationEventHandler = this.__onNavigationEvent.bind(this);
     this.setOutlet(outlet);
@@ -565,13 +569,15 @@ export class Router extends Resolver {
 
     newContext.__divergedChainIndex = 0;
     if (previousChain.length) {
-      for (let i = 0; i < Math.min(previousChain.length, newChain.length); i = ++newContext.__divergedChainIndex) {
-        if (previousChain[i].route !== newChain[i].route
-          || previousChain[i].path !== newChain[i].path
-          || (previousChain[i].element && previousChain[i].element.localName)
-            !== (newChain[i].element && newChain[i].element.localName)
-        ) {
-          break;
+      if (!this.__purgeOutlet) {
+        for (let i = 0; i < Math.min(previousChain.length, newChain.length); i = ++newContext.__divergedChainIndex) {
+          if (previousChain[i].route !== newChain[i].route
+            || previousChain[i].path !== newChain[i].path
+            || (previousChain[i].element && previousChain[i].element.localName)
+              !== (newChain[i].element && newChain[i].element.localName)
+          ) {
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

This change adds an option to disable the optimisation that retains common parent nodes within the outlet on navigation.

Fixes #315.

## Details

Normally while rendering, the router looks for the "deepest common parent" between the previous context and the current context. It will only replace nodes within this common parent. The common parent will remain on the DOM. This optimisation causes issues when navigating to a route that uses the same component as the one you're on and the component renders to the light DOM. See issue #315 for more details.

To fix this, it would be nice to have a way to force the router to replace **all nodes** within the outlet during a navigation irrespective of whether they share a deeper common parent. To do this we want to make sure that `context.__divergedChainIndex` is always `0`. Which will ensure that within `__addAppearingContent()`, `deepestCommonParent` will always be the outlet.

I've created an option called `purgeOutlet` that is passed to the router on creation that does this. I don't really like the name of the option and open to suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/371)
<!-- Reviewable:end -->
