### PR TITLE
WIP: fix: render correctly if reusing the same instance or same tagName

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,6 +1,6 @@
 {
   "excludeFiles": [
-    ".vscode/**",
+    ".*/**",
     "bower_components/**",
     "build/**",
     "demo/**",

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -1686,6 +1686,120 @@
           });
         });
 
+        describe('route.action (function) return the same element tag with different content', () => {
+          let router;
+          beforeEach(() => {
+            router = new Vaadin.Router(outlet);
+          });
+
+          it('should work when reuse the same instance with different content', async() => {
+            let sharedElementInstance = null;
+            let dynamicContent = 'First content';
+            const action = (config) => {
+              const elm = sharedElementInstance || (sharedElementInstance = document.createElement('div'));
+              // clear content
+              elm.innerHTML = '';
+              // Add some new content to the element
+              const content = document.createElement('span');
+              content.textContent = dynamicContent;
+              elm.appendChild(content);
+              // Return always the same instance of the element
+              return elm;
+            };
+            router.setRoutes([
+              {path: '/', action: action}
+            ]);
+
+            await router.render('/');
+            expect(outlet.children[0]).to.be.equal(sharedElementInstance);
+            expect(outlet.textContent).to.be.equal(dynamicContent);
+
+            dynamicContent = 'Second content';
+            // It should not disappear on the secondtime
+            await router.render('/');
+            expect(outlet.children[0]).to.be.equal(sharedElementInstance);
+            expect(outlet.textContent).to.be.equal(dynamicContent);
+          });
+
+          it('should work when return a different instance but same tag name', async() => {
+            let dynamicContent = 'First content';
+            const action = (config) => {
+              const elm = document.createElement('div');
+              // clear content
+              elm.innerHTML = '';
+              // Add some new content to the element
+              const content = document.createElement('span');
+              content.textContent = dynamicContent;
+              elm.appendChild(content);
+              // Return always the same instance of the element
+              return elm;
+            };
+            router.setRoutes([
+              {path: '/', action: action}
+            ]);
+
+            await router.render('/');
+            expect(outlet.textContent).to.be.equal(dynamicContent);
+
+            dynamicContent = 'Second content';
+            // It should not disappear on the secondtime
+            await router.render('/');
+            expect(outlet.textContent).to.be.equal(dynamicContent);
+          });
+
+          it('should work when parent is different but child is the same instance', async() => {
+            const textContent = 'Text content';
+            let sharedElementInstance = null;
+            const action = (config) => {
+              const elm = sharedElementInstance || (sharedElementInstance = document.createElement('x-edit'));
+              // clear content
+              elm.innerHTML = '';
+              // Add some new content to the element
+              const content = document.createElement('span');
+              content.textContent = textContent;
+              elm.appendChild(content);
+              // Return always the same instance of the element
+              return elm;
+            };
+            router.setRoutes([
+              {
+                path: '/users/:name',
+                action: (context) => {
+                  const userEl = document.createElement('x-user');
+                  const avatarEl = document.createElement('x-fancy-name');
+                  avatarEl.textContent = context.params.name;
+                  userEl.appendChild(avatarEl);
+                  return userEl;
+                },
+                children: [
+                  {
+                    path: 'edit',
+                    action: action
+                  },
+                  {
+                    path: 'profile',
+                    component: 'x-profile'
+                  }
+                ]
+              },
+            ]);
+
+            await router.render('/users/john/edit');
+            expect(outlet.children[0].tagName).to.match(/x-user/i);
+            expect(outlet.children[0].children[0].tagName).to.match(/x-fancy-name/i);
+            expect(outlet.children[0].children[0].textContent).to.match(/john/i);
+            expect(outlet.children[0].children[1].tagName).to.match(/x-edit/i);
+            expect(outlet.children[0].children[1].textContent).to.be.equal(textContent);
+            // It should not disappear on the secondtime
+            await router.render('/users/cena/edit');
+            expect(outlet.children[0].tagName).to.match(/x-user/i);
+            expect(outlet.children[0].children[0].tagName).to.match(/x-fancy-name/i);
+            expect(outlet.children[0].children[0].textContent).to.match(/cena/i);
+            expect(outlet.children[0].children[1].tagName).to.match(/x-edit/i);
+            expect(outlet.children[0].children[1].textContent).to.be.equal(textContent);
+          });
+        });
+
         describe('route.children (function)', () => {
           let router;
           beforeEach(() => {


### PR DESCRIPTION
Currently, this test `should work when parent is different but child is the same instance` is broken because of 
```
          // Skip detaching/re-attaching the element it it didn't change from previous rendering
          const sameElement = this.__previousContext && this.__previousContext.result == context.result;
          if (sameElement) {
            this.__previousContext = context;
            return this.location;
          }
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/374)
<!-- Reviewable:end -->
