### PR TITLE
fix: use WeakMap instead of WeakSet

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -222,7 +222,7 @@ export class Router extends Resolver {
     this.__navigationEventHandler = this.__onNavigationEvent.bind(this);
     this.setOutlet(outlet);
     this.subscribe();
-    this.__renderedElements = new WeakSet();
+    this.__renderedElements = new WeakMap();
   }
 
   __resolveRoute(context) {
@@ -247,7 +247,7 @@ export class Router extends Resolver {
       redirect: path => createRedirect(context, path),
       component: (component) => {
         const element = document.createElement(component);
-        this.__renderedElements.add(element);
+        this.__renderedElements.set(element, true);
         return element;
       }
     };
@@ -612,7 +612,7 @@ export class Router extends Resolver {
 
   __isReusableElement(element, otherElement) {
     if (element && otherElement) {
-      return this.__renderedElements.has(otherElement)
+      return this.__renderedElements.get(otherElement)
         ? element.localName === otherElement.localName
         : element === otherElement;
     }


### PR DESCRIPTION
Use `WeakMap` instead of `WeakSet` because `WeakSet` is not supported by  IE11.
Follow up of #375

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/379)
<!-- Reviewable:end -->
