### PR TITLE
fix: prevent executing old render lifecycle callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "bundlesize": [
     {
       "path": "dist/vaadin-router.min.js",
-      "maxSize": "7.5 kB"
+      "maxSize": "7.6 kB"
     }
   ],
   "browserslist": [

--- a/src/router.js
+++ b/src/router.js
@@ -255,7 +255,11 @@ export class Router extends Resolver {
     };
 
     return callbacks
-      .then(() => runCallbackIfPossible(route.action, [context, commands], route))
+      .then(() => {
+        if (context.__renderId === this.__lastStartedRenderId) {
+          return runCallbackIfPossible(route.action, [context, commands], route);
+        }
+      })
       .then(result => {
         if (isResultNotEmpty(result)) {
           // Actions like `() => import('my-view.js')` are not expected to
@@ -442,7 +446,7 @@ export class Router extends Resolver {
     } = isString(pathnameOrContext) ? {pathname: pathnameOrContext, search: '', hash: ''} : pathnameOrContext;
 
     // Find the first route that resolves to a non-empty result
-    this.ready = this.resolve({pathname, search, hash})
+    this.ready = this.resolve({pathname, search, hash, __renderId: renderId})
 
       // Process the result of this.resolve() and handle all special commands:
       // (redirect / prevent / component). If the result is a 'component',
@@ -451,7 +455,7 @@ export class Router extends Resolver {
       .then(context => this.__fullyResolveChain(context))
 
       .then(context => {
-        if (renderId === this.__lastStartedRenderId) {
+        if (context.__renderId === this.__lastStartedRenderId) {
           const previousContext = this.__previousContext;
 
           // Check if the render was prevented and make an early return in that case
@@ -551,7 +555,7 @@ export class Router extends Resolver {
       renderElement(context, result);
       return Promise.resolve(context);
     } else if (result.redirect) {
-      return this.__redirect(result.redirect, context.__redirectCount)
+      return this.__redirect(result.redirect, context.__redirectCount, context.__renderId)
         .then(context => this.__findComponentContextAfterAllRedirects(context));
     } else if (result instanceof Error) {
       return Promise.reject(result);
@@ -605,19 +609,27 @@ export class Router extends Resolver {
 
       for (let i = previousChain.length - 1; !newContext.__skipAttach && i >= newContext.__divergedChainIndex; i--) {
         const location = createLocation(newContext);
-        callbacks = callbacks
-          .then(amend('onBeforeLeave', [location, {prevent}, this], previousChain[i].element))
-          .then(result => {
-            if (!(result || {}).redirect) {
-              return result;
-            }
-          });
+        callbacks = callbacks.then(result => {
+          if (newContext.__renderId === this.__lastStartedRenderId) {
+            const afterLeaveFunction = amend('onBeforeLeave', [location, {prevent}, this], previousChain[i].element);
+            return afterLeaveFunction(result);
+          }
+        }).then(result => {
+          if (!(result || {}).redirect) {
+            return result;
+          }
+        });
       }
     }
 
     for (let i = newContext.__divergedChainIndex; !newContext.__skipAttach && i < newChain.length; i++) {
       const location = createLocation(newContext, newChain[i].route);
-      callbacks = callbacks.then(amend('onBeforeEnter', [location, {prevent, redirect}, this], newChain[i].element));
+      callbacks = callbacks.then(result => {
+        if (newContext.__renderId === this.__lastStartedRenderId) {
+          const beforeEnterFunction = amend('onBeforeEnter', [location, {prevent, redirect}, this], newChain[i].element);
+          return beforeEnterFunction(result);
+        }
+      });
     }
 
     return callbacks.then(amendmentResult => {
@@ -626,7 +638,7 @@ export class Router extends Resolver {
           return this.__previousContext;
         }
         if (amendmentResult.redirect) {
-          return this.__redirect(amendmentResult.redirect, newContext.__redirectCount);
+          return this.__redirect(amendmentResult.redirect, newContext.__redirectCount, newContext.__renderId);
         }
       }
       return newContext;
@@ -642,7 +654,7 @@ export class Router extends Resolver {
     return false;
   }
 
-  __redirect(redirectData, counter) {
+  __redirect(redirectData, counter, renderId) {
     if (counter > MAX_REDIRECT_COUNT) {
       throw new Error(log(`Too many redirects when rendering ${redirectData.from}`));
     }
@@ -653,7 +665,8 @@ export class Router extends Resolver {
         redirectData.params
       ),
       redirectFrom: redirectData.from,
-      __redirectCount: (counter || 0) + 1
+      __redirectCount: (counter || 0) + 1,
+      __renderId: renderId
     });
   }
 
@@ -742,6 +755,9 @@ export class Router extends Resolver {
 
     // REVERSE iteration: from Z to A
     for (let i = targetContext.chain.length - 1; i >= currentContext.__divergedChainIndex; i--) {
+      if (currentContext.__renderId !== this.__lastStartedRenderId) {
+        break;
+      }
       const currentComponent = targetContext.chain[i].element;
       if (!currentComponent) {
         continue;
@@ -763,6 +779,9 @@ export class Router extends Resolver {
   __runOnAfterEnterCallbacks(currentContext) {
     // forward iteration: from A to Z
     for (let i = currentContext.__divergedChainIndex; i < currentContext.chain.length; i++) {
+      if (currentContext.__renderId !== this.__lastStartedRenderId) {
+        break;
+      }
       const currentComponent = currentContext.chain[i].element || {};
       const location = createLocation(currentContext, currentContext.chain[i].route);
       runCallbackIfPossible(

--- a/src/router.js
+++ b/src/router.js
@@ -635,6 +635,7 @@ export class Router extends Resolver {
     return callbacks.then(amendmentResult => {
       if (amendmentResult) {
         if (amendmentResult.cancel) {
+          this.__previousContext.__renderId = newContext.__renderId;
           return this.__previousContext;
         }
         if (amendmentResult.redirect) {

--- a/test/router/lifecycle-events.spec.html
+++ b/test/router/lifecycle-events.spec.html
@@ -123,7 +123,7 @@
           const onBeforeEnter = sinon.spy();
           router.setRoutes([
             {path: '/', action: onBeforeEnterAction('x-home-view', onBeforeEnter)}
-          ]);
+          ], true);
 
           await router.render('/');
 
@@ -1707,6 +1707,298 @@
 
           const event = onError.args[0][0];
           expect(event.detail.pathname).to.equal('/non-existent');
+        });
+      });
+
+      describe('Simultaneous renders', async() => {
+        const PAUSE_TIME = 100; // in ms
+        const sleep = async(ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+        const elementWithAction = elementName => {
+          callbacksLog.push(`${elementName}.action`);
+          const el = document.createElement('x-spy');
+          el.name = elementName;
+          return el;
+        };
+        const elementWithSlowBeforeEnter = elementName => async(context, commands) => {
+          const el = elementWithAction(`${elementName}-render-${context.__renderId}`);
+          el.onBeforeEnter = async() => {
+            callbacksLog.push(`${el.name}.onBeforeEnter`);
+            await sleep(PAUSE_TIME);
+          };
+          return el;
+        };
+        const elementWithSlowBeforeLeave = elementName => async(context, commands) => {
+          const el = elementWithAction(`${elementName}-render-${context.__renderId}`);
+          el.onBeforeLeave = async() => {
+            callbacksLog.push(`${el.name}.onBeforeLeave`);
+            await sleep(PAUSE_TIME);
+          };
+          return el;
+        };
+
+        const elementWithRenderId = elementName => async(context) => {
+          return elementWithAction(`${elementName}-render-${context.__renderId}`);
+        };
+
+
+        it('should only run action when it is the last render', async() => {
+          router.setRoutes([
+            {
+              path: '/',
+              action: async(context) => {
+                const el = elementWithAction(`x-parent-layout-render-${context.__renderId}`);
+                await sleep(PAUSE_TIME);
+                return el;
+              },
+              children: [
+                {
+                  path: 'a',
+                  action: context => elementWithAction(`x-a-render-${context.__renderId}`)
+                },
+                {
+                  path: 'b',
+                  action: context => elementWithAction(`x-b-render-${context.__renderId}`)
+                }
+              ]
+            }
+          ], true);
+          callbacksLog = [];
+          router.render('/a');
+          // render another path just before it runs action of `a`
+          await sleep(PAUSE_TIME * 0.9);
+          await router.render('/b');
+
+          verifyCallbacks([
+            'x-parent-layout-render-1.action',
+            'x-parent-layout-render-2.action',
+            'x-b-render-2.action',
+            'x-parent-layout-render-2.onBeforeEnter',
+            'x-b-render-2.onBeforeEnter',
+            'x-parent-layout-render-2.connectedCallback',
+            'x-b-render-2.connectedCallback',
+            'x-parent-layout-render-2.onAfterEnter',
+            'x-b-render-2.onAfterEnter'
+          ]);
+        });
+
+        it('should only run onBeforeEnter events when it is the last render', async() => {
+          router.setRoutes([
+            {
+              path: '/',
+              action: elementWithSlowBeforeEnter('x-parent-layout'),
+              children: [
+                {
+                  path: 'a',
+                  action: elementWithSlowBeforeEnter('x-a')
+                },
+                {
+                  path: 'b',
+                  action: elementWithSlowBeforeEnter('x-b')
+                }
+              ]
+            }
+          ], true);
+          callbacksLog = [];
+          router.render('/a');
+          // wait until the end of parent.onBeforeEnter
+          // then trigger a new render
+          // so that `x-a.onBeforeEnter` won't be executed
+          await sleep(PAUSE_TIME * 0.9);
+          await router.render('/b');
+          await router.ready;
+          verifyCallbacks([
+            'x-parent-layout-render-1.action',
+            'x-a-render-1.action',
+            'x-parent-layout-render-1.onBeforeEnter',
+            'x-parent-layout-render-2.action',
+            'x-b-render-2.action',
+            'x-parent-layout-render-2.onBeforeEnter',
+            'x-b-render-2.onBeforeEnter',
+            'x-parent-layout-render-2.connectedCallback',
+            'x-b-render-2.connectedCallback',
+            'x-parent-layout-render-2.onAfterEnter',
+            'x-b-render-2.onAfterEnter'
+          ]);
+        });
+
+        it('should stop running onBeforeEnter events immediately when there is a new render', async() => {
+          router.setRoutes([
+            {
+              path: '/',
+              action: elementWithSlowBeforeEnter('x-parent-layout'),
+              children: [
+                {
+                  path: 'a',
+                  action: elementWithSlowBeforeEnter('x-a'),
+                  children: [
+                    {
+                      path: 'a-child',
+                      action: elementWithSlowBeforeEnter('x-a-child'),
+                    }
+                  ]
+                },
+                {
+                  path: 'b',
+                  action: elementWithSlowBeforeEnter('x-b')
+                }
+              ]
+            }
+          ], true);
+          callbacksLog = [];
+          router.render('/a/a-child');
+          // give it enough time for running `parent.onBeforeEnter` and `x-a.onBeforeEnter`
+          // then start a new render,
+          // so `a-child.onBeforeEnter` shouldn't run at all
+          await sleep(PAUSE_TIME * 1.5);
+          await router.render('/b');
+          verifyCallbacks([
+            'x-parent-layout-render-1.action',
+            'x-a-render-1.action',
+            'x-a-child-render-1.action',
+            'x-parent-layout-render-1.onBeforeEnter',
+            'x-a-render-1.onBeforeEnter',
+            'x-parent-layout-render-2.action',
+            'x-b-render-2.action',
+            'x-parent-layout-render-2.onBeforeEnter',
+            'x-b-render-2.onBeforeEnter',
+            'x-parent-layout-render-2.connectedCallback',
+            'x-b-render-2.connectedCallback',
+            'x-parent-layout-render-2.onAfterEnter',
+            'x-b-render-2.onAfterEnter'
+          ]);
+        });
+        it('should only run onBeforeLeave events when it is the last render', async() => {
+          router.setRoutes([
+            {
+              path: '/',
+              action: elementWithSlowBeforeLeave('x-parent-layout'),
+              children: [
+                {
+                  path: 'a',
+                  action: elementWithSlowBeforeLeave('x-a'),
+                  children: [
+                    {
+                      path: 'a-child',
+                      action: elementWithSlowBeforeLeave('x-a-child')
+                    }
+                  ]
+                },
+                {
+                  path: 'b',
+                  action: elementWithSlowBeforeLeave('x-b')
+                }
+              ]
+            }
+          ], true);
+          await router.render('/a/a-child');
+          callbacksLog = [];
+          router.render('/b');
+          await sleep(PAUSE_TIME * 0.9);
+          await router.render('/a/a-child');
+          verifyActiveRoutes(router, ['/', 'a', 'a-child']);
+          verifyCallbacks([
+            'x-parent-layout-render-2.action',
+            'x-b-render-2.action',
+            'x-a-child-render-1.onBeforeLeave',
+            'x-parent-layout-render-3.action',
+            'x-a-render-3.action',
+            'x-a-child-render-3.action',
+            'x-a-child-render-1.onBeforeLeave',
+            'x-a-render-1.onBeforeLeave',
+            'x-parent-layout-render-1.onBeforeLeave',
+            'x-parent-layout-render-3.onBeforeEnter',
+            'x-a-render-3.onBeforeEnter',
+            'x-a-child-render-3.onBeforeEnter',
+            'x-parent-layout-render-3.connectedCallback',
+            'x-a-render-3.connectedCallback',
+            'x-a-child-render-3.connectedCallback',
+            'x-parent-layout-render-3.onAfterEnter',
+            'x-a-render-3.onAfterEnter',
+            'x-a-child-render-3.onAfterEnter',
+            'x-a-child-render-1.onAfterLeave',
+            'x-a-render-1.onAfterLeave',
+            'x-parent-layout-render-1.onAfterLeave',
+            'x-a-render-1.disconnectedCallback',
+            'x-a-child-render-1.disconnectedCallback',
+            'x-parent-layout-render-1.disconnectedCallback'
+          ]);
+        });
+
+        it('should only run onAfterEnter/onAfterLeave events when it is the last render', (done) => {
+          router.setRoutes([
+            {
+              path: '/',
+              action: elementWithRenderId('x-parent-layout'),
+              children: [
+                {
+                  path: 'a',
+                  action: elementWithRenderId('x-a'),
+                  children: [
+                    {
+                      path: 'a-child',
+                      action: elementWithRenderId('x-a-child'),
+                    }
+                  ]
+                },
+                {
+                  path: 'b',
+                  action: elementWithRenderId('x-b')
+                }
+              ]
+            }
+          ], true);
+          const waitForLocation = async(event) => {
+            if (event.detail.location.pathname === '/b') {
+              window.removeEventListener('vaadin-router-location-changed', waitForLocation);
+              await router.render('/a/a-child');
+              try {
+                verifyActiveRoutes(router, ['/', 'a', 'a-child']);
+                verifyCallbacks([
+                  'x-parent-layout-render-2.action',
+                  'x-b-render-2.action',
+                  'x-a-render-1.onBeforeLeave',
+                  'x-parent-layout-render-1.onBeforeLeave',
+                  'x-parent-layout-render-2.onBeforeEnter',
+                  'x-b-render-2.onBeforeEnter',
+                  'x-parent-layout-render-2.connectedCallback',
+                  'x-b-render-2.connectedCallback',
+                  // x-b-render-2.onAfterEnter is not executed here
+                  // because the 3rd render already started
+                  'x-parent-layout-render-3.action',
+                  'x-a-render-3.action',
+                  'x-a-child-render-3.action',
+                  'x-a-render-1.onBeforeLeave',
+                  'x-parent-layout-render-1.onBeforeLeave',
+                  'x-parent-layout-render-3.onBeforeEnter',
+                  'x-a-render-3.onBeforeEnter',
+                  'x-a-child-render-3.onBeforeEnter',
+                  'x-parent-layout-render-2.disconnectedCallback',
+                  'x-b-render-2.disconnectedCallback',
+                  'x-parent-layout-render-3.connectedCallback',
+                  'x-a-render-3.connectedCallback',
+                  'x-a-child-render-3.connectedCallback',
+                  'x-parent-layout-render-3.onAfterEnter',
+                  'x-a-render-3.onAfterEnter',
+                  'x-a-child-render-3.onAfterEnter',
+                  'x-a-render-1.onAfterLeave',
+                  'x-parent-layout-render-1.onAfterLeave',
+                  'x-a-render-1.disconnectedCallback',
+                  'x-parent-layout-render-1.disconnectedCallback',
+                ]);
+                done();
+              } catch (e) {
+                done(e);
+              }
+            }
+          };
+          // Attach a listener to `location-changed` event to trigger another render
+          // because the event happens just before 'onAfterEnter'/'onAfterLeave'.
+          window.addEventListener('vaadin-router-location-changed', waitForLocation);
+          router.render('/a').then(() => {
+            callbacksLog = [];
+            router.render('/b');
+          });
         });
       });
     });

--- a/test/router/router.spec.html
+++ b/test/router/router.spec.html
@@ -1279,7 +1279,7 @@
             router.setRoutes([
               {path: '/', bundle: existingBundlePath, action: removeBundleAndReturn},
               {path: '/', component: 'x-home-view'},
-            ]);
+            ], true);
 
             await router.render('/');
 


### PR DESCRIPTION
Stop executing lifecycle callbacks (`action`, `onBeforeLeave`, `onBeforeEnter`, `onAfterEnter`, `onAfterLeave`) when the current render is out of date because there is a new render.

Fixes #378

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/385)
<!-- Reviewable:end -->
