### PR TITLE
chore: fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: bionic
-sudo: required
+dist: xenial
+sudo: false
 language: node_js
 node_js: 10
 


### PR DESCRIPTION
For unknown reasons, `wct --env saucelabs` doesn't work on `bionic` but it is fine in `xenial`. So I change it to `xenial` to keep the build green on master
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/394)
<!-- Reviewable:end -->
