### PR TITLE
Allow unknown property names in the Routes

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -76,6 +76,8 @@ declare namespace Router {
     children?: Route[] | ChildrenFn;
     component?: string;
     redirect?: string;
+    // Allow unknown property names
+    [key: string]: any;
   }
   interface RouteWithAction extends BaseRoute {
     action: ActionFn;


### PR DESCRIPTION
I want to propose this change, because we use the Route to send more info.
For example, a title and a description:

<img width="374" alt="Screenshot 2019-10-21 at 21 31 01" src="https://user-images.githubusercontent.com/1007051/67209542-2363a180-f44a-11e9-8ac5-aeb822e2e0b5.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/405)
<!-- Reviewable:end -->
