### PR TITLE
chore(tsconfig): set skipLibCheck: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rollup-plugin-commonjs": "^10.0.2",
     "rollup-plugin-node-resolve": "^5.2.0",
     "stylelint": "^10.1.0",
-    "stylelint-config-vaadin": "latest",
+    "stylelint-config-vaadin": "^0.1.4",
     "typescript": "^3.5.3",
     "uglify-es": "^3.3.9",
     "wct-istanbul": "^0.14.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "experimentalDecorators": true,
     "outDir": "ts-dist",
     "declaration": true,
+    "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "@vaadin/router": ["dist/vaadin-router"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,7 +220,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
+"@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.2.tgz#ea8334dc77416bfd9473eb470fd00d8245b3943b"
   integrity sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==
@@ -7201,7 +7201,7 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0, micromatch@^4.0.2:
+micromatch@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
@@ -10269,28 +10269,10 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
 
-stylelint-config-styled-components@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/stylelint-config-styled-components/-/stylelint-config-styled-components-0.1.1.tgz#b408388d7c687833ab4be4c4e6522d97d2827ede"
-  integrity sha512-z5Xz/9GmvxO6e/DLzBMwkB85zHxEEjN6K7Cj80Bi+o/9vR9eS3GX3E9VuMnX9WLFYulqbqLtTapGGY28JBiy9Q==
-
-stylelint-config-vaadin@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/stylelint-config-vaadin/-/stylelint-config-vaadin-0.2.1.tgz#ffd30d77ee0ba4062f8ac7421838dbd1eb311830"
-  integrity sha512-1BDyVG/W7fjq4lC7KSOOvRsDTtcb5pW+L2dU+1iFi60/vR6Nh3z8uD5KHNzjevoJW0WRTbp0C4BX/Oo1B8WkoQ==
-  dependencies:
-    stylelint-config-styled-components "^0.1.0"
-    stylelint-processor-styled-components "^1.8.0"
-
-stylelint-processor-styled-components@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.8.0.tgz#7dc48c6c95f9c3c9daa49efa5f3d1be49e7296e2"
-  integrity sha512-sADydhLPwtR9YJBydlO6X209sjT3rG9nr7sn/cEFZtoeZF3tI60HtxIOFC12vVVMvpKFS+E0smMiKA6FcVZO9A==
-  dependencies:
-    "@babel/parser" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    micromatch "^4.0.2"
-    postcss "^7.0.0"
+stylelint-config-vaadin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/stylelint-config-vaadin/-/stylelint-config-vaadin-0.1.4.tgz#bc3161ffb1eb27039e08cc875f1b6e32ab01f03a"
+  integrity sha512-OpjDsasSV8bQAvs7OjRaGF0Gj7mFDh6PEgOfdxTgYj0CJY5XAey9mLa7rJQcnJ1uzkm6TIeHR81tT+N6eSFrTg==
 
 stylelint@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
Fixes #411 

We encountered the error caused by `'vfile-message'` in the components, too.
Setting `skipLibCheck` seems like a proper way to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/420)
<!-- Reviewable:end -->
