### PR TITLE
test(router): matching child not under first parent

### DIFF
--- a/test/router/parent-layouts.spec.html
+++ b/test/router/parent-layouts.spec.html
@@ -208,6 +208,30 @@
         checkOutlet(['x-fallback']);
       });
 
+      it('should render the matching child route even if it is not under the first matching parent', async() => {
+        router.setRoutes([
+          {
+            path: '/',
+            component: 'x-layout-a',
+            children: [
+              {path: '/a', component: 'x-a'},
+            ]
+          },
+          {
+            path: '/',
+            component: 'x-layout-b',
+            children: [
+              {path: '/b', component: 'x-b'}
+            ]
+          },
+        ]);
+
+        await router.render('/b');
+
+        verifyActiveRoutes(router, ['/', '/b']);
+        checkOutlet(['x-layout-b', 'x-b']);
+      });
+
       it('redirect property amends previous path', async() => {
         router.setRoutes([
           {path: '/a', component: 'x-a', children: [


### PR DESCRIPTION
Fixes #307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-router/438)
<!-- Reviewable:end -->
