### PR TITLE
fix: skip undefined base argument in URL constructor

### DIFF
--- a/index.polyfilled.js
+++ b/index.polyfilled.js
@@ -57,12 +57,13 @@ Resolver.__ensureUrlAvailableOrPolyfilled = () => {
   }
 };
 
-Resolver.__createUrl = (path, base) => {
+Resolver.__createUrl = (...args) => {
   Resolver.__ensureUrlAvailableOrPolyfilled();
   if (isUrlAvailable) {
-    return new URL(path, base);
+    return new URL(...args);
   }
 
+  const [path, base] = args;
   urlBase.href = base;
   urlAnchor.href = path.replace(/ /g, '%20');
   // IE11: only absolute href setting results in correct part properties

--- a/src/resolver/resolver.js
+++ b/src/resolver/resolver.js
@@ -206,8 +206,8 @@ class Resolver {
   /**
    * URL constructor polyfill hook. Creates and returns an URL instance.
    */
-  static __createUrl(url, base) {
-    return new URL(url, base);
+  static __createUrl(...args) {
+    return new URL(...args);
   }
 
   /**


### PR DESCRIPTION
In Safari before 14.0, URL constructor throws when the `base` second
argument is `undefined`. This change prevents invoking URL with
undefined base argument when the argument is omitted in `__createUrl`.